### PR TITLE
Added support for Bulgarian language with several new Options

### DIFF
--- a/src/Nut.Demo/MoneyToText.Designer.cs
+++ b/src/Nut.Demo/MoneyToText.Designer.cs
@@ -34,6 +34,8 @@
             this.cbCurrencyFirstCharUpper = new System.Windows.Forms.CheckBox();
             this.cbMainUnitNotConvertedToText = new System.Windows.Forms.CheckBox();
             this.cbSubUnitFirstCharUpper = new System.Windows.Forms.CheckBox();
+            this.cbAddAndBetweenUnits = new System.Windows.Forms.CheckBox();
+            this.cbUseShortenedUnits = new System.Windows.Forms.CheckBox();
             this.SuspendLayout();
             // 
             // btnMoneyToText
@@ -71,7 +73,7 @@
             // 
             // txtResultText
             // 
-            this.txtResultText.Location = new System.Drawing.Point(30, 183);
+            this.txtResultText.Location = new System.Drawing.Point(30, 206);
             this.txtResultText.Multiline = true;
             this.txtResultText.Name = "txtResultText";
             this.txtResultText.Size = new System.Drawing.Size(488, 75);
@@ -137,11 +139,33 @@
             this.cbSubUnitFirstCharUpper.Text = "Sub-unit First Char Upper";
             this.cbSubUnitFirstCharUpper.UseVisualStyleBackColor = true;
             // 
+            // cbAddAndBetweenUnits
+            // 
+            this.cbAddAndBetweenUnits.AutoSize = true;
+            this.cbAddAndBetweenUnits.Location = new System.Drawing.Point(30, 179);
+            this.cbAddAndBetweenUnits.Name = "cbAddAndBetweenUnits";
+            this.cbAddAndBetweenUnits.Size = new System.Drawing.Size(186, 17);
+            this.cbAddAndBetweenUnits.TabIndex = 18;
+            this.cbAddAndBetweenUnits.Text = "Add & between Main and Sub units";
+            this.cbAddAndBetweenUnits.UseVisualStyleBackColor = true;
+            // 
+            // cbUseShortenedUnits
+            // 
+            this.cbUseShortenedUnits.AutoSize = true;
+            this.cbUseShortenedUnits.Location = new System.Drawing.Point(217, 179);
+            this.cbUseShortenedUnits.Name = "cbUseShortenedUnits";
+            this.cbUseShortenedUnits.Size = new System.Drawing.Size(169, 17);
+            this.cbUseShortenedUnits.TabIndex = 17;
+            this.cbUseShortenedUnits.Text = "Use shortened version of units";
+            this.cbUseShortenedUnits.UseVisualStyleBackColor = true;
+            // 
             // MoneyToText
             // 
             this.AutoScaleDimensions = new System.Drawing.SizeF(6F, 13F);
             this.AutoScaleMode = System.Windows.Forms.AutoScaleMode.Font;
             this.ClientSize = new System.Drawing.Size(551, 293);
+            this.Controls.Add(this.cbAddAndBetweenUnits);
+            this.Controls.Add(this.cbUseShortenedUnits);
             this.Controls.Add(this.cbSubUnitFirstCharUpper);
             this.Controls.Add(this.cbMainUnitNotConvertedToText);
             this.Controls.Add(this.cbCurrencyFirstCharUpper);
@@ -173,5 +197,7 @@
         private System.Windows.Forms.CheckBox cbCurrencyFirstCharUpper;
         private System.Windows.Forms.CheckBox cbMainUnitNotConvertedToText;
         private System.Windows.Forms.CheckBox cbSubUnitFirstCharUpper;
+        private System.Windows.Forms.CheckBox cbAddAndBetweenUnits;
+        private System.Windows.Forms.CheckBox cbUseShortenedUnits;
     }
 }

--- a/src/Nut.Demo/MoneyToText.cs
+++ b/src/Nut.Demo/MoneyToText.cs
@@ -8,8 +8,8 @@ namespace Nut.Demo {
     public partial class MoneyToText : Form {
         public MoneyToText() {
             InitializeComponent();
-            cmbLang.DataSource = new List<string>() { "en", "es", "fr", "ru", "tr", "ua" };
-            cmbCurrency.DataSource = new List<string>() { "usd", "eur", "rub", "try", "uah" };
+            cmbLang.DataSource = new List<string>() { "en", "es", "fr", "ru", "tr", "ua", "bg" };
+            cmbCurrency.DataSource = new List<string>() { "usd", "eur", "rub", "try", "uah", "bgn" };
         }
 
         private void btnMoneyToText_Click(object sender, EventArgs e) {
@@ -22,6 +22,8 @@ namespace Nut.Demo {
                 SubUnitFirstCharUpper = cbSubUnitFirstCharUpper.Checked,
                 CurrencyFirstCharUpper = cbCurrencyFirstCharUpper.Checked,
                 SubUnitZeroNotDisplayed = cbSubUnitZeroNotIncluded.Checked,
+                AddAndBetweenMainUnitAndSubUnits = cbAddAndBetweenUnits.Checked,
+                UseShortenedUnits = cbUseShortenedUnits.Checked
             };
             var text = Convert.ToDecimal(txtNumber.Text, CultureInfo.CurrentCulture).ToText(currency, lang, options);
             txtResultText.Text = text;

--- a/src/Nut.Demo/NumberToText.cs
+++ b/src/Nut.Demo/NumberToText.cs
@@ -17,7 +17,7 @@ namespace Nut.Demo
         {
             InitializeComponent();
 
-            cmbLang.DataSource = new List<string>() { "en", "es", "fr", "ru", "tr", "ua" };
+            cmbLang.DataSource = new List<string>() { "en", "es", "fr", "ru", "tr", "ua", "bg" };
         }
 
         private void btnNumberToText_Click(object sender, EventArgs e)

--- a/src/Nut/Constants.cs
+++ b/src/Nut/Constants.cs
@@ -14,6 +14,7 @@
         public const string Spanish = "es";
         public const string Turkish = "tr";
         public const string Ukrainian = "ua";
+        public const string Bulgarian = "bg";
     }
 
     public static class Culture
@@ -26,6 +27,7 @@
         public const string Spanish = "es-ES";
         public const string Turkish = "tr-TR";
         public const string Ukrainian = "uk-UA";
+        public const string Bulgarian = "bg-BG";
     }
 
     public static class Currency
@@ -36,6 +38,7 @@
         public const string TRY = "try";
         public const string USD = "usd";
         public const string UAH = "uah";
+        public const string BGN = "bgn";
     }
 
 }

--- a/src/Nut/Extentions.cs
+++ b/src/Nut/Extentions.cs
@@ -39,6 +39,10 @@ namespace Nut
                 case Culture.Ukrainian:
                     text = UkrainianConverter.Instance.ToText(num);
                     break;
+                case Language.Bulgarian:
+                case Culture.Bulgarian:
+                    text = BulgarianConverter.Instance.ToText(num);
+                    break;
             }
             return text;
         }
@@ -72,6 +76,10 @@ namespace Nut
                 case Language.Ukrainian:
                 case Culture.Ukrainian:
                     text = UkrainianConverter.Instance.ToText(num, currency, options);
+                    break;
+                case Language.Bulgarian:
+                case Culture.Bulgarian:
+                    text = BulgarianConverter.Instance.ToText(num, currency, options);
                     break;
             }
             return text;

--- a/src/Nut/Models/CurrencyModel.cs
+++ b/src/Nut/Models/CurrencyModel.cs
@@ -4,5 +4,7 @@
     {
         public string Currency { get; set; }
         public BaseCurrencyModel SubUnitCurrency { get; set; }
+        public string ShortUnitCurrency { get; set; }
+        public string ShortSubUnitCurrency { get; set; }
     }
 }

--- a/src/Nut/Nut.csproj
+++ b/src/Nut/Nut.csproj
@@ -51,6 +51,7 @@
     <Compile Include="Models\CurrencyModel.cs" />
     <Compile Include="Properties\AssemblyInfo.cs" />
     <Compile Include="TextConverters\BaseConverter.cs" />
+    <Compile Include="TextConverters\BulgarianConverter.cs" />
     <Compile Include="TextConverters\FrenchConverter.cs" />
     <Compile Include="TextConverters\EnglishConverter.cs" />
     <Compile Include="TextConverters\RussianConverter.cs" />

--- a/src/Nut/Options.cs
+++ b/src/Nut/Options.cs
@@ -8,5 +8,7 @@
         public bool MainUnitFirstCharUpper { get; set; }
         public bool SubUnitFirstCharUpper { get; set; }
         public bool CurrencyFirstCharUpper { get; set; }
+        public bool AddAndBetweenMainUnitAndSubUnits { get; set; }
+        public bool UseShortenedUnits { get; set; }
     }
 }

--- a/src/Nut/TextConverters/BaseConverter.cs
+++ b/src/Nut/TextConverters/BaseConverter.cs
@@ -2,6 +2,7 @@
 using System.Collections.Generic;
 using System.Globalization;
 using System.Linq;
+using System.Net.Configuration;
 using System.Text;
 using Nut.Models;
 
@@ -152,7 +153,7 @@ namespace Nut.TextConverters
 
             builder.Append(" ");
 
-            var currencyText = GetCurrencyText(mainUnitNum, currencyModel);
+            var currencyText = GetCurrencyText(mainUnitNum, currencyModel, options.UseShortenedUnits);
             currencyText = options.CurrencyFirstCharUpper ? currencyText.ToFirstLetterUpper(CultureName) : currencyText;
             builder.Append(currencyText);
 
@@ -163,7 +164,7 @@ namespace Nut.TextConverters
                 var subUnitNum = Convert.ToInt64(subUnitText);
                 if (!options.SubUnitZeroNotDisplayed || subUnitNum != 0)
                 {
-                    builder.Append(" ");
+                    builder.Append(GetUnitSeparator(currencyModel, options.AddAndBetweenMainUnitAndSubUnits));
 
                     if (options.SubUnitNotConvertedToText)
                     {
@@ -177,7 +178,7 @@ namespace Nut.TextConverters
 
                     builder.Append(" ");
 
-                    var subUnitCurrencyText = GetSubUnitCurrencyText(subUnitNum, currencyModel);
+                    var subUnitCurrencyText = GetSubUnitCurrencyText(subUnitNum, currencyModel, options.UseShortenedUnits);
                     subUnitCurrencyText = options.CurrencyFirstCharUpper ? subUnitCurrencyText.ToFirstLetterUpper(CultureName) : subUnitCurrencyText;
                     builder.Append(subUnitCurrencyText);
                 }
@@ -187,18 +188,23 @@ namespace Nut.TextConverters
             return builder.ToString().Trim();
         }
 
-        protected virtual string GetCurrencyText(long num, CurrencyModel currency)
+        protected virtual string GetCurrencyText(long num, CurrencyModel currency, bool useShortModel)
         {
             return num > 1 ? currency.Names[1] : currency.Names[0];
         }
 
-        protected virtual string GetSubUnitCurrencyText(long num, CurrencyModel currency)
+        protected virtual string GetSubUnitCurrencyText(long num, CurrencyModel currency, bool useShortModel)
         {
             return num > 1 ? currency.SubUnitCurrency.Names[1] : currency.SubUnitCurrency.Names[0];
         }
         protected virtual CurrencyModel GetCurrencyModel(string currency)
         {
             return null;
+        }
+
+        protected virtual string GetUnitSeparator(CurrencyModel currency, bool addAndAsUnitSeparator)
+        {
+            return " ";
         }
         #endregion
     }

--- a/src/Nut/TextConverters/BulgarianConverter.cs
+++ b/src/Nut/TextConverters/BulgarianConverter.cs
@@ -1,0 +1,272 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+using Nut.Models;
+
+namespace Nut.TextConverters
+{
+    public class BulgarianConverter : BaseConverter
+    {
+        private static Lazy<BulgarianConverter> Lazy = new Lazy<BulgarianConverter>(() => new BulgarianConverter());
+        public static BulgarianConverter Instance => Lazy.Value;
+        public override string CultureName { get; } = Culture.Bulgarian;
+
+        protected int textType = 0;
+
+        public BulgarianConverter()
+        {
+            Initialize();
+        }
+
+        protected override string ToText(long num, CurrencyModel currencyModel, bool isMainUnit)
+        {
+            switch (currencyModel.Currency)
+            {
+                case Currency.RUB:
+                    NumberTexts[2][0] = isMainUnit ? "два" : "две";
+                    break;
+                case Currency.EUR:
+                    NumberTexts[2][0] = isMainUnit ? "два" : "две";
+                    break;
+                default:
+                    NumberTexts[2][0] = "два";
+                    break;
+            }
+            return ToText(num);
+        }
+
+        protected override long Append(long num, long scale, StringBuilder builder)
+        {
+            if (num > scale - 1)
+            {
+                var baseScale = num / scale;
+
+                textType = scale < 999 ? GetTextType(baseScale) : (num == scale ? 0 : 1);
+
+                var baseUnitNumber = baseScale % 10;
+
+                if (scale == 1000 && baseUnitNumber == 1 && num > 1)
+                    textType = 3;
+
+                if (scale == 1000 && textType < 3 && (baseUnitNumber == 1 || baseUnitNumber == 2))
+                {
+                    AppendLessThanOneThousandForAdditional(baseScale, builder);
+                }
+                else
+                {
+                    AppendLessThanOneThousand(baseScale, builder);
+                }
+
+                builder.AppendFormat("{0} ", ScaleTexts[scale][textType > 0 ? 1 : 0]);
+                num = num - (baseScale * scale);
+                textType = 0;
+            }
+            return base.Append(num, scale, builder);
+        }
+
+        protected override void AppendLessThanOneThousand(long num, StringBuilder builder)
+        {
+            num = AppendHundreds(num, builder);
+            num = AppendTens(num, builder);
+            if (num == 1 && builder.ToString().Trim().Length == 0) return;
+            AppendUnits(num, builder);
+        }
+
+        private void AppendLessThanOneThousandForAdditional(long num, StringBuilder builder)
+        {
+            num = AppendHundreds(num, builder);
+            num = AppendTens(num, builder);
+            if (num == 1 && builder.ToString().Trim().Length == 0) return;
+            AppendUnits(num, builder);
+        }
+
+        protected override long AppendHundreds(long num, StringBuilder builder)
+        {
+            if (num > 99)
+            {
+                if (num % 100 == 0 && builder.ToString().Trim().Length > 0)
+                    builder.Append("и ");
+                var hundreds = num / 100 * 100;
+                builder.AppendFormat("{0} ", NumberTexts[hundreds][0]);
+                num = num - hundreds;
+            }
+            return num;
+        }
+
+        protected override long AppendTens(long num, StringBuilder builder)
+        {
+            if (num > 20 && num % 10 == 0 && builder.ToString().Trim().Length > 0)
+                builder.Append("и ");
+            return base.AppendTens(num, builder);
+        }
+
+        protected override void AppendUnits(long num, StringBuilder builder)
+        {
+            if (num > 0)
+            {
+                if (builder.ToString().Trim().Length > 0)
+                    builder.Append("и ");
+                var targetType = Math.Min(NumberTexts[num].Length - 1, textType);
+                builder.AppendFormat("{0} ", NumberTexts[num][targetType]);
+            }
+        }
+
+        protected override void AppendUnitsForAdditional(long num, StringBuilder builder)
+        {
+            if (num != 0 && builder.ToString().Trim().Length > 0)
+                builder.Append("и ");
+            base.AppendUnitsForAdditional(num, builder);
+        }
+
+        private byte GetTextType(long num)
+        {
+            const int femmeMinBaseScale = 2;
+            const int pluralMinBaseScale = 5;
+
+            var baseUnitNumber = num % 10;
+            var baseTens = num % 100;
+
+            if (baseTens < 10 || baseTens > 20)
+            {
+                if (baseUnitNumber == 1)
+                    return 0;
+                if (baseUnitNumber >= femmeMinBaseScale && baseUnitNumber < pluralMinBaseScale)
+                    return 1;
+            }
+            return 0;
+        }
+
+        private void Initialize()
+        {
+            NumberTexts.Add(0, new[] { "нула" });
+            NumberTexts.Add(1, new[] { "един", "едно", "една" });
+            NumberTexts.Add(2, new[] { "два", "две" });
+            NumberTexts.Add(3, new[] { "три" });
+            NumberTexts.Add(4, new[] { "четири" });
+            NumberTexts.Add(5, new[] { "пет" });
+            NumberTexts.Add(6, new[] { "шест" });
+            NumberTexts.Add(7, new[] { "седем" });
+            NumberTexts.Add(8, new[] { "осем" });
+            NumberTexts.Add(9, new[] { "девет" });
+            NumberTexts.Add(10, new[] { "десет" });
+            NumberTexts.Add(11, new[] { "единадесет" });
+            NumberTexts.Add(12, new[] { "дванадесет" });
+            NumberTexts.Add(13, new[] { "тринадесет" });
+            NumberTexts.Add(14, new[] { "четиринадесет" });
+            NumberTexts.Add(15, new[] { "пeтнадесет" });
+            NumberTexts.Add(16, new[] { "шестнадесет" });
+            NumberTexts.Add(17, new[] { "седемнадесет" });
+            NumberTexts.Add(18, new[] { "осемнадесет" });
+            NumberTexts.Add(19, new[] { "деветнадесет" });
+            NumberTexts.Add(20, new[] { "двадесет" });
+            NumberTexts.Add(30, new[] { "тридесет" });
+            NumberTexts.Add(40, new[] { "четиридесет" });
+            NumberTexts.Add(50, new[] { "петдесет" });
+            NumberTexts.Add(60, new[] { "шестдесет" });
+            NumberTexts.Add(70, new[] { "седемдесет" });
+            NumberTexts.Add(80, new[] { "осемдесет" });
+            NumberTexts.Add(90, new[] { "деветдесет" });
+            NumberTexts.Add(100, new[] { "сто" });
+            NumberTexts.Add(200, new[] { "двеста" });
+            NumberTexts.Add(300, new[] { "триста" });
+            NumberTexts.Add(400, new[] { "четиристотин" });
+            NumberTexts.Add(500, new[] { "петстотин" });
+            NumberTexts.Add(600, new[] { "шестстотин" });
+            NumberTexts.Add(700, new[] { "седемстотин" });
+            NumberTexts.Add(800, new[] { "осемстотин" });
+            NumberTexts.Add(900, new[] { "деветстотин" });
+
+            ScaleTexts.Add(1000000000, new[] { "милиард", "милиарда" });
+            ScaleTexts.Add(1000000, new[] { "милион", "милиона" });
+            ScaleTexts.Add(1000, new[] { "хиляда", "хиляди" });
+        }
+
+        #region Currency
+
+        protected override string GetCurrencyText(long num, CurrencyModel currency, bool useShort)
+        {
+            if (useShort)
+                return currency.ShortUnitCurrency;
+            var textType = num == 1 ? 0 : 1;
+            return currency.Names[textType];
+        }
+
+        protected override string GetSubUnitCurrencyText(long num, CurrencyModel currency, bool useShort)
+        {
+            if (useShort)
+                return currency.ShortSubUnitCurrency;
+            var textType = num == 1 ? 0 : 1;
+            return currency.SubUnitCurrency.Names[textType];
+        }
+
+        protected override CurrencyModel GetCurrencyModel(string currency)
+        {
+            switch (currency)
+            {
+                case Currency.EUR:
+                    return new CurrencyModel
+                    {
+                        Currency = currency,
+                        Names = new[] { "евро", "евро", "евро" },
+                        SubUnitCurrency = new BaseCurrencyModel { Names = new[] { "евроцент", "евроцента", "евроцента" } },
+                        ShortUnitCurrency = "ев.",
+                        ShortSubUnitCurrency = "цт."
+                    };
+                case Currency.USD:
+                    return new CurrencyModel
+                    {
+                        Currency = currency,
+                        Names = new[] { "долар", "долара", "долара" },
+                        SubUnitCurrency = new BaseCurrencyModel { Names = new[] { "цент", "цента", "цента" } },
+                        ShortUnitCurrency = "дл.",
+                        ShortSubUnitCurrency = "цт."
+                    };
+                case Currency.RUB:
+                    return new CurrencyModel
+                    {
+                        Currency = currency,
+                        Names = new[] { "рубли", "рубли", "рубли" },
+                        SubUnitCurrency = new BaseCurrencyModel { Names = new[] { "копейки", "копейки", "копейки" } },
+                        ShortUnitCurrency = "рб.",
+                        ShortSubUnitCurrency = "кп."
+                    };
+                case Currency.TRY:
+                    return new CurrencyModel
+                    {
+                        Currency = currency,
+                        Names = new[] { "турска лира", "турска лира", "турска лира" },
+                        SubUnitCurrency = new BaseCurrencyModel { Names = new[] { "куруш", "куруши", "куруши" } },
+                        ShortUnitCurrency = "тл.",
+                        ShortSubUnitCurrency = "кр."
+                    };
+                case Currency.UAH:
+                    return new CurrencyModel
+                    {
+                        Currency = currency,
+                        Names = new[] { "гривня", "гривни", "гривни" },
+                        SubUnitCurrency = new BaseCurrencyModel { Names = new[] { "копейка", "копейки", "копейки" } },
+                        ShortUnitCurrency = "гр.",
+                        ShortSubUnitCurrency = "кп."
+                    };
+                case Currency.BGN:
+                    return new CurrencyModel {
+                        Currency = currency,
+                        Names = new[] {"лев", "лева", "лева"},
+                        SubUnitCurrency = new BaseCurrencyModel {Names = new[] {"стотинка", "стотинки", "стотинки"}},
+                        ShortUnitCurrency = "лв.",
+                        ShortSubUnitCurrency = "ст."
+                    };
+            }
+            return null;
+        }
+
+        protected override string GetUnitSeparator(CurrencyModel currency, bool addAndAsUnitSeparator)
+        {
+            return addAndAsUnitSeparator ? " и " : " ";
+        }
+
+        #endregion
+    }
+}

--- a/src/Nut/TextConverters/BulgarianConverter.cs
+++ b/src/Nut/TextConverters/BulgarianConverter.cs
@@ -43,11 +43,11 @@ namespace Nut.TextConverters
             {
                 var baseScale = num / scale;
 
-                textType = scale < 999 ? GetTextType(baseScale) : (num == scale ? 0 : 1);
+                textType = scale < 999 ? GetTextType(baseScale) : (num < 2000 ? 0 : 1);
 
                 var baseUnitNumber = baseScale % 10;
 
-                if (scale == 1000 && baseUnitNumber == 1 && num > 1)
+                if (scale == 1000 && baseUnitNumber == 1 && num > 10000)
                     textType = 3;
 
                 if (scale == 1000 && textType < 3 && (baseUnitNumber == 1 || baseUnitNumber == 2))
@@ -155,7 +155,7 @@ namespace Nut.TextConverters
             NumberTexts.Add(12, new[] { "дванадесет" });
             NumberTexts.Add(13, new[] { "тринадесет" });
             NumberTexts.Add(14, new[] { "четиринадесет" });
-            NumberTexts.Add(15, new[] { "пeтнадесет" });
+            NumberTexts.Add(15, new[] { "петнадесет" });
             NumberTexts.Add(16, new[] { "шестнадесет" });
             NumberTexts.Add(17, new[] { "седемнадесет" });
             NumberTexts.Add(18, new[] { "осемнадесет" });

--- a/src/Nut/TextConverters/RussianConverter.cs
+++ b/src/Nut/TextConverters/RussianConverter.cs
@@ -151,14 +151,16 @@ namespace Nut.TextConverters
 
         #region Currency
 
-        protected override string GetCurrencyText(long num, CurrencyModel currency)
+        protected override string GetCurrencyText(long num, CurrencyModel currency, bool useShort)
         {
+            // TODO: add short unit usage
             var textType = GetTextType(num);
             return currency.Names[textType - 1];
         }
 
-        protected override string GetSubUnitCurrencyText(long num, CurrencyModel currency)
+        protected override string GetSubUnitCurrencyText(long num, CurrencyModel currency, bool useShort)
         {
+            // TODO: add short unit usage
             var textType = GetTextType(num);
             return currency.SubUnitCurrency.Names[textType - 1];
         }

--- a/src/Nut/TextConverters/UkrainianConverter.cs
+++ b/src/Nut/TextConverters/UkrainianConverter.cs
@@ -137,14 +137,16 @@ namespace Nut.TextConverters
 
         #region Currency
 
-        protected override string GetCurrencyText(long num, CurrencyModel currency)
+        protected override string GetCurrencyText(long num, CurrencyModel currency, bool useShort)
         {
+            // TODO: add short unit usage
             var textType = GetTextType(num);
             return currency.Names[textType - 1];
         }
 
-        protected override string GetSubUnitCurrencyText(long num, CurrencyModel currency)
+        protected override string GetSubUnitCurrencyText(long num, CurrencyModel currency, bool useshort)
         {
+            // TODO: add short unit usage
             var textType = GetTextType(num);
             return currency.SubUnitCurrency.Names[textType - 1];
         }


### PR DESCRIPTION
* Added bulgarian language
* Added option to put & between Main and Sub units
* Added option to use shortened strings for currency

These options currently only apply for the Bulgarian language, other languages should also be updated to include the new one as well as the new options.

If I have time later on I could update other languages as well.