### PR TITLE
Adition of ARS (Argentine Pesos) along with fixes in Spanish 

### DIFF
--- a/src/Nut.Demo/MoneyToText.cs
+++ b/src/Nut.Demo/MoneyToText.cs
@@ -9,7 +9,7 @@ namespace Nut.Demo {
         public MoneyToText() {
             InitializeComponent();
             cmbLang.DataSource = new List<string>() { "en", "es", "fr", "ru", "tr", "ua", "bg" };
-            cmbCurrency.DataSource = new List<string>() { "usd", "eur", "rub", "try", "uah", "bgn" };
+            cmbCurrency.DataSource = new List<string>() { "usd", "eur", "rub", "try", "uah", "bgn", "ars" };
         }
 
         private void btnMoneyToText_Click(object sender, EventArgs e) {

--- a/src/Nut/Constants.cs
+++ b/src/Nut/Constants.cs
@@ -39,6 +39,7 @@
         public const string USD = "usd";
         public const string UAH = "uah";
         public const string BGN = "bgn";
+        public const string ARS = "ars";
     }
 
 }

--- a/src/Nut/TextConverters/BaseConverter.cs
+++ b/src/Nut/TextConverters/BaseConverter.cs
@@ -173,6 +173,7 @@ namespace Nut.TextConverters
                     else {
                         subUnitText = ToText(subUnitNum, currencyModel, false);
                         subUnitText = options.SubUnitFirstCharUpper ? subUnitText.ToFirstLetterUpper(CultureName) : subUnitText;
+                        builder.Append(GetConnectorBetweenMainAndDecimal());
                         builder.Append(subUnitText);
                     }
 
@@ -186,6 +187,11 @@ namespace Nut.TextConverters
             }
 
             return builder.ToString().Trim();
+        }
+
+        protected virtual string GetConnectorBetweenMainAndDecimal()
+        {
+            return " ";
         }
 
         protected virtual string GetCurrencyText(long num, CurrencyModel currency, bool useShortModel)

--- a/src/Nut/TextConverters/SpanishConverter.cs
+++ b/src/Nut/TextConverters/SpanishConverter.cs
@@ -29,6 +29,11 @@ namespace Nut.TextConverters
             return base.ToText(num, currencyModel, isMainUnit, genderGroup);
         }
 
+        protected override string GetConnectorBetweenMainAndDecimal()
+        {
+            return "con ";
+        }
+
         protected override long Append(long num, long scale, StringBuilder builder)
         {
             if (num > scale - 1)
@@ -38,15 +43,17 @@ namespace Nut.TextConverters
                 {
                     AppendUnitsForAdditional(baseScale, builder);
                 }
-                else {
+                else
+                {
                     AppendLessThanOneThousand(baseScale, builder);
                 }
 
-                if (scale == 1000000 && num > 1)
+                if (scale == 1000000 && num / scale > 1)
                 {
                     builder.AppendFormat("{0} ", ScaleTexts[scale][2]);
                 }
-                else {
+                else
+                {
                     builder.AppendFormat("{0} ", ScaleTexts[scale][0]);
                 }
 
@@ -73,7 +80,10 @@ namespace Nut.TextConverters
             if (num > 99)
             {
                 var hundreds = num / 100 * 100;
-                builder.AppendFormat("{0} ", NumberTexts[hundreds][0]);
+                if (num % 100 > 0)
+                    builder.AppendFormat("{0} ", NumberTexts[hundreds][1]);
+                else
+                    builder.AppendFormat("{0} ", NumberTexts[hundreds][0]);
                 num = num - hundreds;
             }
             return num;
@@ -171,6 +181,13 @@ namespace Nut.TextConverters
                         Currency = currency,
                         Names = new[] { "grivna ucraniana", "grivnas ucraniana" },
                         SubUnitCurrency = new BaseCurrencyModel { Names = new[] { "kopek", "kopeks" } }
+                    };
+                case Currency.ARS:
+                    return new CurrencyModel
+                    {
+                        Currency = currency,
+                        Names = new[] { "peso", "pesos" },
+                        SubUnitCurrency = new BaseCurrencyModel { Names = new[] { "centavo", "centavos" } }
                     };
             }
             return null;


### PR DESCRIPTION
I've added Argentine Pesos (ARS) as a new money option. I've also made some fixes in how the Spanish text is generated:
- Fix in the hundred part of the text: now the text makes the difference between "cien" and "ciento".
- Fix in the way the main number and the decimal part is connected (in money generation): I've added a generic connector function to allow place a word between main and decimal part. In Spanish the connector word is "con", so, 1.20 now it's "un peso con veinte centavos". 