### PR TITLE
Add english and french missing unit separator translation and a new option to choose if it must be translated or not

### DIFF
--- a/src/Nut/Options.cs
+++ b/src/Nut/Options.cs
@@ -8,5 +8,6 @@
         public bool MainUnitFirstCharUpper { get; set; }
         public bool SubUnitFirstCharUpper { get; set; }
         public bool CurrencyFirstCharUpper { get; set; }
+		public bool RadixInCurrencyNotConvertedToText { get; set; }
     }
 }

--- a/src/Nut/Options.cs
+++ b/src/Nut/Options.cs
@@ -8,6 +8,6 @@
         public bool MainUnitFirstCharUpper { get; set; }
         public bool SubUnitFirstCharUpper { get; set; }
         public bool CurrencyFirstCharUpper { get; set; }
-		public bool RadixInCurrencyNotConvertedToText { get; set; }
+        public bool RadixInCurrencyNotConvertedToText { get; set; }
     }
 }

--- a/src/Nut/TextConverters/BaseConverter.cs
+++ b/src/Nut/TextConverters/BaseConverter.cs
@@ -164,7 +164,10 @@ namespace Nut.TextConverters
         var subUnitNum = Convert.ToInt64(subUnitText);
         if (!options.SubUnitZeroNotDisplayed || subUnitNum != 0)
         {
-          builder.Append(GetUnitSeparator(currencyModel));
+          if (options.RadixInCurrencyNotConvertedToText)
+            builder.Append(" "); 
+          else
+            builder.Append(GetUnitSeparator(currencyModel));
 
           if (options.SubUnitNotConvertedToText)
           {

--- a/src/Nut/TextConverters/EnglishConverter.cs
+++ b/src/Nut/TextConverters/EnglishConverter.cs
@@ -117,5 +117,10 @@ namespace Nut.TextConverters
             }
             return null;
         }
+		
+		protected override string GetUnitSeparator(CurrencyModel currency)
+        {
+            return " and ";
+        }
     }
 }

--- a/src/Nut/TextConverters/FrenchConverter.cs
+++ b/src/Nut/TextConverters/FrenchConverter.cs
@@ -191,5 +191,10 @@ namespace Nut.TextConverters
       }
       return null;
     }
+	
+	protected override string GetUnitSeparator(CurrencyModel currency)
+	{
+		return " et ";
+	}
   }
 }


### PR DESCRIPTION
(New pull request since they was indentation problem with the #15.)

In french and english converter, the unit separator wasn't translated.

As in some kind of situation, we need the radix to be translated or not. I propose to add a new option "RadixInCurrencyNotConvertedToText" that is set to false by default (so we did not change the behaviour)

For example, in french, 100,23EUR could be ever translated in theses both sentences :

Cent euros et vingt-trois centimes
Cent euros vingt-trois centimes