### PR TITLE
ci: net10.0 + tag-driven NuGet publishing

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -15,5 +15,5 @@ jobs:
       - uses: actions/checkout@v5
       - uses: actions/setup-dotnet@v5
         with:
-          dotnet-version: 8.0.x
+          dotnet-version: 10.0.x
       - run: dotnet test src/Nut.sln --configuration Release

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -12,8 +12,8 @@ jobs:
   build:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v5
-      - uses: actions/setup-dotnet@v5
+      - uses: actions/checkout@v7
+      - uses: actions/setup-dotnet@v6
         with:
           dotnet-version: 10.0.x
       - run: dotnet test src/Nut.sln --configuration Release

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -11,8 +11,8 @@ jobs:
   publish:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v5
-      - uses: actions/setup-dotnet@v5
+      - uses: actions/checkout@v7
+      - uses: actions/setup-dotnet@v6
         with:
           dotnet-version: 10.0.x
 

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,32 @@
+name: Release
+
+on:
+  push:
+    tags: ['v*']
+
+permissions:
+  contents: write
+
+jobs:
+  publish:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v5
+      - uses: actions/setup-dotnet@v5
+        with:
+          dotnet-version: 10.0.x
+
+      - run: dotnet test src/Nut.sln --configuration Release
+
+      - name: Pack
+        run: dotnet pack src/Nut/Nut.csproj --configuration Release -p:Version="${GITHUB_REF_NAME#v}" -o out
+
+      - name: Push to NuGet
+        env:
+          NUGET_API_KEY: ${{ secrets.NUGET_API_KEY }}
+        run: dotnet nuget push "out/*.nupkg" -s https://api.nuget.org/v3/index.json -k "$NUGET_API_KEY"
+
+      - name: Create GitHub release
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: gh release create "$GITHUB_REF_NAME" out/*.nupkg --generate-notes

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -24,7 +24,7 @@ jobs:
 
       - name: Authenticate to NuGet
         id: nuget-login
-        uses: NuGet/login@v1
+        uses: NuGet/login@8d196754b4036150537f80ac539e15c2f1028841 # v1.2.0
         with:
           user: emrahyumuk
 

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -6,6 +6,7 @@ on:
 
 permissions:
   contents: write
+  id-token: write
 
 jobs:
   publish:
@@ -21,9 +22,15 @@ jobs:
       - name: Pack
         run: dotnet pack src/Nut/Nut.csproj --configuration Release -p:Version="${GITHUB_REF_NAME#v}" -o out
 
+      - name: Authenticate to NuGet
+        id: nuget-login
+        uses: NuGet/login@v1
+        with:
+          user: emrahyumuk
+
       - name: Push to NuGet
         env:
-          NUGET_API_KEY: ${{ secrets.NUGET_API_KEY }}
+          NUGET_API_KEY: ${{ steps.nuget-login.outputs.NUGET_API_KEY }}
         run: dotnet nuget push "out/*.nupkg" -s https://api.nuget.org/v3/index.json -k "$NUGET_API_KEY"
 
       - name: Create GitHub release

--- a/src/Nut.Tests/Nut.Tests.csproj
+++ b/src/Nut.Tests/Nut.Tests.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>net8.0</TargetFramework>
+    <TargetFramework>net10.0</TargetFramework>
     <ImplicitUsings>enable</ImplicitUsings>
     <Nullable>enable</Nullable>
 

--- a/src/Nut/Nut.csproj
+++ b/src/Nut/Nut.csproj
@@ -2,9 +2,7 @@
 
   <PropertyGroup>
     <TargetFramework>netstandard2.0</TargetFramework>
-    <GeneratePackageOnBuild>true</GeneratePackageOnBuild>
     <PackageId>Nut</PackageId>
-    <PackageVersion>3.4.1</PackageVersion>
     <Title>Nut (Number to Text)</Title>
     <Authors>Emrah Yumuk</Authors>
     <Description>Number To Text Converter
@@ -21,9 +19,6 @@ Number Limit: 1 trillion</Description>
     <RepositoryType>git</RepositoryType>
     <PackageReadmeFile>README.md</PackageReadmeFile>
     <PackageTags>number, text, word, money, english, french, turkish, spanish, russian, german currency, try, usd, euro, rub, number, to money, currency, int, decimal, ukranian, UAH, bulgarian, portuguese, BRL, BGN, amharic, ETB, polish, PLN, Belarussian, BLN, ARS, argentine pesos</PackageTags>
-    <PackageReleaseNotes>- added German language</PackageReleaseNotes>
-    <AssemblyVersion>3.4.1</AssemblyVersion>
-    <FileVersion>3.4.1</FileVersion>
   </PropertyGroup>
   <ItemGroup>
     <None Include="..\..\README.md" Pack="true" PackagePath="\"/>


### PR DESCRIPTION
Follow-up to #29. Makes releases reproducible so the backlog can ship as one version.

## Release flow after this

| Stage | Trigger | Publishes? |
|---|---|---|
| PR opened / pushed | `dotnet test` | no |
| Merge to master | `dotnet test` | no |
| **`git tag v3.5.0 && git push origin v3.5.0`** | test → pack → NuGet → GitHub release | **yes** |

Merging never publishes. Tagging is the single human decision.

## Changes

- **Version removed from `Nut.csproj`.** It was hardcoded in `PackageVersion`, `AssemblyVersion` and `FileVersion`; #27 and #28 both edit those lines and collide there for no reason. The tag is now the only source of truth — the workflow passes `-p:Version="${GITHUB_REF_NAME#v}"`.
- **`release.yml`** — runs on `v*` tags. Tests before packing, so a broken tag cannot reach NuGet. Uses the preinstalled `gh` CLI for the GitHub release instead of a third-party action.
- **NuGet auth via Trusted Publishing** (`NuGet/login@v1` + `id-token: write`). NuGet.org discourages API keys for automated publishing; the workflow exchanges the GitHub OIDC token for a short-lived key at run time. No secret to store or rotate.
- **`net8.0` → `net10.0`** for tests and CI. .NET 8 leaves LTS support in November 2026; 10 is the current LTS. `Nut` stays on `netstandard2.0`.
- **Dropped `GeneratePackageOnBuild`** — it built a nupkg on every CI test run and nothing consumed it.
- **Dropped `PackageReleaseNotes`**, which still read "added German language" from 3.4.1. `--generate-notes` covers this from now on.

## Prerequisites

The trusted publishing policy on NuGet.org must stay bound to `release.yml` in this repo — renaming the workflow file breaks publishing until the policy is updated.

Last publish was 3.4.1 in 2023, so the first tag after the PR backlog clears should be `v3.5.0`.