### PR TITLE
test: characterize current behaviour across all 12 languages

### DIFF
--- a/src/Nut.Tests/KnownDefects.cs
+++ b/src/Nut.Tests/KnownDefects.cs
@@ -1,0 +1,152 @@
+using System;
+
+namespace Nut.Tests
+{
+    /// <summary>
+    /// Defects that are reproducible today. Each test asserts the WRONG behaviour on
+    /// purpose, so the suite stays green until someone fixes the defect — at which point
+    /// the test fails and has to be rewritten as the correct expectation. Every case here
+    /// was reproduced against the library before being written down.
+    /// </summary>
+    [TestFixture]
+    public class KnownDefects
+    {
+        /// <summary>
+        /// Extentions.cs lowercases the language argument on the int overloads, but the
+        /// Culture constants are mixed case ("en-US"), so no case ever matches and the
+        /// caller silently gets "". The long and decimal overloads do not lowercase and
+        /// work fine, so the same culture string succeeds or fails depending on the
+        /// numeric type it is called on.
+        /// </summary>
+        [TestCase(Culture.EnglishUS)]
+        [TestCase(Culture.EnglishGB)]
+        [TestCase(Culture.French)]
+        [TestCase(Culture.Russian)]
+        [TestCase(Culture.Spanish)]
+        [TestCase(Culture.Turkish)]
+        [TestCase(Culture.Ukrainian)]
+        [TestCase(Culture.Bulgarian)]
+        [TestCase(Culture.EthiopianAM)]
+        [TestCase(Culture.Polish)]
+        [TestCase(Culture.Belarusian)]
+        [TestCase(Culture.PortugueseBR)]
+        [TestCase(Culture.GermanDE)]
+        public void CultureCodesReturnEmptyOnTheIntOverload(string culture)
+        {
+            Assert.That(101.ToText(culture), Is.Empty);
+        }
+
+        [Test]
+        public void SameCultureWorksOnTheLongOverload()
+        {
+            Assert.That(101L.ToText(Culture.EnglishUS), Is.EqualTo("one hundred one"));
+        }
+
+        [Test]
+        public void UppercaseCurrencyCodeReturnsEmpty()
+        {
+            Assert.That(41m.ToText("USD", Language.English), Is.Empty);
+            Assert.That(41m.ToText("usd", Language.English), Is.Not.Empty);
+        }
+
+        /// <summary>
+        /// The Slavic converters assign into the singleton's shared word table to pick a
+        /// gender, and never restore it. A plain ToText(long) carries no currency context
+        /// yet still returns whatever the previous conversion left behind, so the same
+        /// input produces different output depending on call order. Under concurrent load
+        /// this also corrupts results outright.
+        /// </summary>
+        [Test]
+        public void RussianOneDependsOnThePreviousCurrencyConversion()
+        {
+            1m.ToText(Currency.USD, Language.Russian); // default branch leaves masculine
+            var afterDollar = 1L.ToText(Language.Russian);
+
+            1m.ToText(Currency.RUB, Language.Russian); // sub-unit pass leaves feminine
+            var afterRuble = 1L.ToText(Language.Russian);
+
+            Assert.That(afterDollar, Is.EqualTo("один"));
+            Assert.That(afterRuble, Is.EqualTo("одна"));
+            Assert.That(afterDollar, Is.Not.EqualTo(afterRuble), "same call, different answers");
+
+            1m.ToText(Currency.USD, Language.Russian); // leave the table as we found it
+        }
+
+        /// <summary>Thousands take the feminine form in these languages; millions stay masculine.</summary>
+        [Test]
+        public void RussianThousandsUseTheMasculineFormInstead()
+        {
+            Assert.That(41000m.ToText(Currency.RUB, Language.Russian),
+                Is.EqualTo("сорок один тысяча рублей ноль копеек")); // "сорок одна тысяча"
+            Assert.That(42000m.ToText(Currency.RUB, Language.Russian),
+                Is.EqualTo("сорок два тысячи рублей ноль копеек")); // "сорок две тысячи"
+        }
+
+        [Test]
+        public void BelarusianHasTheSameThousandsDefect()
+        {
+            Assert.That(41000m.ToText(Currency.BYN, Language.Belarusian),
+                Is.EqualTo("сорак адзін тысяча беларускіх рублёў нуль капеек")); // "сорак адна тысяча"
+        }
+
+        /// <summary>Ukrainian is wrong in the opposite direction: its table is feminine-first,
+        /// so thousands come out right and millions come out feminine.</summary>
+        [Test]
+        public void UkrainianMillionsUseTheFeminineFormInstead()
+        {
+            Assert.That(1000000m.ToText(Currency.UAH, Language.Ukrainian),
+                Is.EqualTo("Одна мільйон гривень Нуль копійок")); // "Один мільйон"
+        }
+
+        [Test]
+        public void RussianTurkishLiraIsNotDeclined()
+        {
+            Assert.That(1m.ToText(Currency.TRY, Language.Russian),
+                Is.EqualTo("один турецкая лира ноль курушей")); // лира is feminine -> "одна"
+        }
+
+        [Test]
+        public void BulgarianOneIsEmpty()
+        {
+            Assert.That(1L.ToText(Language.Bulgarian), Is.Empty); // "един"
+            Assert.That(21L.ToText(Language.Bulgarian), Is.EqualTo("двадесет и един")); // works inside compounds
+        }
+
+        [Test]
+        public void BulgarianDropsTheCountEntirely()
+        {
+            Assert.That(1m.ToText(Currency.BGN, Language.Bulgarian),
+                Is.EqualTo("лев и нула стотинки")); // "един лев"
+            Assert.That(1000000L.ToText(Language.Bulgarian), Is.EqualTo("милиона")); // "един милион"
+        }
+
+        /// <summary>Every Append* helper guards with "num > x", so a negative number matches
+        /// nothing and falls through to an empty string. On the money overload the integer
+        /// part vanishes while the fraction survives, producing a plausible-looking but
+        /// completely wrong amount.</summary>
+        [Test]
+        public void NegativeNumbersProduceEmptyOrWrongText()
+        {
+            Assert.That((-5L).ToText(Language.English), Is.Empty);
+            Assert.That((-41.5m).ToText(Currency.USD, Language.English),
+                Is.EqualTo("dollar fifty cents")); // the 41 and the minus are both gone
+        }
+
+        /// <summary>BaseConverter pads the fraction to two digits but never trims it, so a
+        /// third decimal is read as if it were part of the sub-unit count.</summary>
+        [Test]
+        public void MoreThanTwoDecimalsAreReadAsWholeSubUnits()
+        {
+            Assert.That(123.456m.ToText(Currency.USD, Language.English),
+                Is.EqualTo("one hundred twenty three dollars four hundred fifty six cents"));
+        }
+
+        /// <summary>Callers cannot catch this selectively.</summary>
+        [Test]
+        public void OverTheLimitThrowsBareException()
+        {
+            var ex = Assert.Throws<Exception>(() => 1000000000000L.ToText(Language.English));
+            Assert.That(ex.GetType(), Is.EqualTo(typeof(Exception)));
+        }
+    }
+}

--- a/src/Nut.Tests/KnownDefects.cs
+++ b/src/Nut.Tests/KnownDefects.cs
@@ -90,7 +90,8 @@ namespace Nut.Tests
         }
 
         /// <summary>Ukrainian is wrong in the opposite direction: its table is feminine-first,
-        /// so thousands come out right and millions come out feminine.</summary>
+        /// so thousands come out right and millions come out feminine. тисяча is feminine,
+        /// мільйон is masculine, so the correct forms are "одна тисяча" and "один мільйон".</summary>
         [Test]
         public void UkrainianMillionsUseTheFeminineFormInstead()
         {

--- a/src/Nut.Tests/NumberBaseline.cs
+++ b/src/Nut.Tests/NumberBaseline.cs
@@ -24,7 +24,7 @@ namespace Nut.Tests
         [TestCase(11, "eleven")]
         [TestCase(15, "fifteen")]
         [TestCase(20, "twenty")]
-        [TestCase(21, "twenty one")] // BUG: English hyphenates compounds -> "twenty-one"
+        [TestCase(21, "twenty one")] // BUG: compounds 21-99 are always hyphenated -> "twenty-one" (Merriam-Webster)
         [TestCase(42, "forty two")] // BUG: -> "forty-two"
         [TestCase(100, "one hundred")]
         [TestCase(101, "one hundred one")]
@@ -41,25 +41,26 @@ namespace Nut.Tests
         [TestCase(11, "onze")]
         [TestCase(20, "vingt")]
         [TestCase(21, "vingt et un")]
-        [TestCase(42, "quarante deux")] // BUG: post-1990 spelling hyphenates -> "quarante-deux"
+        [TestCase(42, "quarante deux")] // BUG: hyphenated both traditionally and post-1990 -> "quarante-deux" (BDL/Académie)
         [TestCase(100, "cent")]
         [TestCase(101, "cent un")]
-        [TestCase(200, "deux cent")] // BUG: a multiplied "cent" with nothing after it takes -s -> "deux cents"
-        [TestCase(999, "neuf cent quatre-vingt-dix-neuf")]
+        [TestCase(200, "deux cent")] // BUG: multiplied "cent" with nothing after it takes -s -> "deux cents" (BDL)
+        [TestCase(999, "neuf cent quatre-vingt-dix-neuf")] // hyphenated here but not at 42 — inconsistent
         [TestCase(1000, "mille")]
         [TestCase(41000, "quarante et un mille")]
         [TestCase(1000000, "un million")]
-        [TestCase(2000000, "deux million")] // BUG: -> "deux millions"
+        [TestCase(2000000, "deux million")] // BUG: million is a noun and takes -s -> "deux millions"
         [TestCase(1000000000, "un milliard")]
         public void French(long number, string expected) => Check(number, Language.French, expected);
 
         [TestCase(0, "null")]
-        [TestCase(1, "ein")] // BUG: standalone one is "eins"; "ein" is the attributive form
+        [TestCase(1, "ein")] // BUG: standalone one is "eins"; "ein" is only attributive (Duden)
         [TestCase(11, "elf")]
         [TestCase(20, "zwanzig")]
         [TestCase(21, "einundzwanzig")]
         [TestCase(42, "zweiundvierzig")]
-        [TestCase(100, "ein hundert")] // BUG: German writes numbers closed up -> "einhundert"
+        // Duden: numbers below a million are written as one closed-up word, above a million separated.
+        [TestCase(100, "ein hundert")] // BUG: -> "einhundert"
         [TestCase(101, "ein hundert ein")] // BUG: -> "einhunderteins"
         [TestCase(999, "neun hundert neunundneunzig")] // BUG: -> "neunhundertneunundneunzig"
         [TestCase(1000, "eintausend")] // closed up here, but not at 2000 — inconsistent
@@ -79,13 +80,16 @@ namespace Nut.Tests
         [TestCase(100, "cien")]
         [TestCase(101, "ciento uno")]
         [TestCase(200, "doscientos")]
-        [TestCase(999, "novecientas noventa y nueve")] // BUG: feminine hundreds by default; 200 uses masculine
-        [TestCase(1000, "uno mil")] // BUG: Spanish has no "uno mil" -> "mil"
+        [TestCase(999, "novecientas noventa y nueve")] // BUG: feminine hundreds by default while 200 is masculine — RAE: gender follows the noun, so the bare form should be masculine
+        // RAE: "mil" forces apocope of uno -> "un". "uno mil" / "cuarenta y uno mil" are not Spanish.
+        [TestCase(1000, "uno mil")] // BUG: -> "mil"
         [TestCase(2000, "dos mil")]
-        [TestCase(41000, "cuarenta y uno mil")] // BUG: apocope -> "cuarenta y un mil"
+        [TestCase(41000, "cuarenta y uno mil")] // BUG: -> "cuarenta y un mil"
         [TestCase(1000000, "uno millón")] // BUG: -> "un millón"
         [TestCase(2000000, "dos millones")]
-        [TestCase(1000000000, "uno billón")] // BUG: Spanish billón is 10^12; 10^9 is "mil millones"
+        // BUG, worst in the file: RAE/FundéuRAE — Spanish "billón" is 10^12, not the English
+        // billion. 10^9 is "mil millones" (or "millardo"), so this is off by a factor of 1000.
+        [TestCase(1000000000, "uno billón")]
         public void Spanish(long number, string expected) => Check(number, Language.Spanish, expected);
 
         [TestCase(0, "zero")]
@@ -98,7 +102,7 @@ namespace Nut.Tests
         [TestCase(101, "cento e um")]
         [TestCase(200, "duzentos")]
         [TestCase(999, "novecentos e noventa e nove")]
-        [TestCase(1000, "um mil")] // BUG: -> "mil"
+        [TestCase(1000, "um mil")] // "mil" is the usual reading, but "um mil" is accepted and common on cheques — not a defect
         [TestCase(41000, "quarenta e um mil")]
         [TestCase(1000000, "um milhão")]
         [TestCase(2000000, "dois milhões")]

--- a/src/Nut.Tests/NumberBaseline.cs
+++ b/src/Nut.Tests/NumberBaseline.cs
@@ -1,0 +1,190 @@
+namespace Nut.Tests
+{
+    /// <summary>
+    /// Pins the current plain-number output of every language so later refactors have to
+    /// declare what they change. Values here are what the library produces today, which is
+    /// not always what the language actually requires — cases known to be wrong carry a
+    /// BUG comment and are expected to change when that defect is fixed.
+    ///
+    /// Numbers containing 1 or 2 are missing for Russian, Ukrainian, Belarusian and
+    /// Bulgarian on purpose: those converters rewrite their shared word table at runtime,
+    /// so the result depends on what ran before. See <see cref="KnownDefects"/>.
+    /// </summary>
+    [TestFixture]
+    public class NumberBaseline
+    {
+        private static void Check(long number, string lang, string expected)
+        {
+            Assert.That(number.ToText(lang), Is.EqualTo(expected));
+        }
+
+        [TestCase(0, "zero")]
+        [TestCase(1, "one")]
+        [TestCase(2, "two")]
+        [TestCase(11, "eleven")]
+        [TestCase(15, "fifteen")]
+        [TestCase(20, "twenty")]
+        [TestCase(21, "twenty one")] // BUG: English hyphenates compounds -> "twenty-one"
+        [TestCase(42, "forty two")] // BUG: -> "forty-two"
+        [TestCase(100, "one hundred")]
+        [TestCase(101, "one hundred one")]
+        [TestCase(200, "two hundred")]
+        [TestCase(999, "nine hundred ninety nine")]
+        [TestCase(1000, "one thousand")]
+        [TestCase(41000, "forty one thousand")]
+        [TestCase(1000000, "one million")]
+        [TestCase(1000000000, "one billion")]
+        public void English(long number, string expected) => Check(number, Language.English, expected);
+
+        [TestCase(0, "zéro")]
+        [TestCase(1, "un")]
+        [TestCase(11, "onze")]
+        [TestCase(20, "vingt")]
+        [TestCase(21, "vingt et un")]
+        [TestCase(42, "quarante deux")] // BUG: post-1990 spelling hyphenates -> "quarante-deux"
+        [TestCase(100, "cent")]
+        [TestCase(101, "cent un")]
+        [TestCase(200, "deux cent")] // BUG: a multiplied "cent" with nothing after it takes -s -> "deux cents"
+        [TestCase(999, "neuf cent quatre-vingt-dix-neuf")]
+        [TestCase(1000, "mille")]
+        [TestCase(41000, "quarante et un mille")]
+        [TestCase(1000000, "un million")]
+        [TestCase(2000000, "deux million")] // BUG: -> "deux millions"
+        [TestCase(1000000000, "un milliard")]
+        public void French(long number, string expected) => Check(number, Language.French, expected);
+
+        [TestCase(0, "null")]
+        [TestCase(1, "ein")] // BUG: standalone one is "eins"; "ein" is the attributive form
+        [TestCase(11, "elf")]
+        [TestCase(20, "zwanzig")]
+        [TestCase(21, "einundzwanzig")]
+        [TestCase(42, "zweiundvierzig")]
+        [TestCase(100, "ein hundert")] // BUG: German writes numbers closed up -> "einhundert"
+        [TestCase(101, "ein hundert ein")] // BUG: -> "einhunderteins"
+        [TestCase(999, "neun hundert neunundneunzig")] // BUG: -> "neunhundertneunundneunzig"
+        [TestCase(1000, "eintausend")] // closed up here, but not at 2000 — inconsistent
+        [TestCase(2000, "zwei tausend")] // BUG: -> "zweitausend"
+        [TestCase(41000, "einundvierzig tausend")] // BUG: -> "einundvierzigtausend"
+        [TestCase(1000000, "eine Million")]
+        [TestCase(2000000, "zwei Millionen")]
+        [TestCase(1000000000, "eine Milliarde")]
+        public void German(long number, string expected) => Check(number, Language.German, expected);
+
+        [TestCase(0, "cero")]
+        [TestCase(1, "uno")]
+        [TestCase(11, "once")]
+        [TestCase(20, "veinte")]
+        [TestCase(21, "veintiún")]
+        [TestCase(42, "cuarenta y dos")]
+        [TestCase(100, "cien")]
+        [TestCase(101, "ciento uno")]
+        [TestCase(200, "doscientos")]
+        [TestCase(999, "novecientas noventa y nueve")] // BUG: feminine hundreds by default; 200 uses masculine
+        [TestCase(1000, "uno mil")] // BUG: Spanish has no "uno mil" -> "mil"
+        [TestCase(2000, "dos mil")]
+        [TestCase(41000, "cuarenta y uno mil")] // BUG: apocope -> "cuarenta y un mil"
+        [TestCase(1000000, "uno millón")] // BUG: -> "un millón"
+        [TestCase(2000000, "dos millones")]
+        [TestCase(1000000000, "uno billón")] // BUG: Spanish billón is 10^12; 10^9 is "mil millones"
+        public void Spanish(long number, string expected) => Check(number, Language.Spanish, expected);
+
+        [TestCase(0, "zero")]
+        [TestCase(1, "um")]
+        [TestCase(11, "onze")]
+        [TestCase(20, "vinte")]
+        [TestCase(21, "vinte e um")]
+        [TestCase(42, "quarenta e dois")]
+        [TestCase(100, "cem")]
+        [TestCase(101, "cento e um")]
+        [TestCase(200, "duzentos")]
+        [TestCase(999, "novecentos e noventa e nove")]
+        [TestCase(1000, "um mil")] // BUG: -> "mil"
+        [TestCase(41000, "quarenta e um mil")]
+        [TestCase(1000000, "um milhão")]
+        [TestCase(2000000, "dois milhões")]
+        [TestCase(1000000000, "um bilhão")]
+        public void Portuguese(long number, string expected) => Check(number, Language.Portuguese, expected);
+
+        [TestCase(0, "sıfır")]
+        [TestCase(1, "bir")]
+        [TestCase(11, "on bir")]
+        [TestCase(20, "yirmi")]
+        [TestCase(21, "yirmi bir")]
+        [TestCase(42, "kırk iki")]
+        [TestCase(100, "yüz")]
+        [TestCase(101, "yüz bir")]
+        [TestCase(200, "iki yüz")]
+        [TestCase(999, "dokuz yüz doksan dokuz")]
+        [TestCase(1000, "bin")]
+        [TestCase(2000, "iki bin")]
+        [TestCase(41000, "kırk bir bin")]
+        [TestCase(1000000, "bir milyon")]
+        [TestCase(1000000000, "bir milyar")]
+        public void Turkish(long number, string expected) => Check(number, Language.Turkish, expected);
+
+        [TestCase(0, "ноль")]
+        [TestCase(3, "три")]
+        [TestCase(11, "одиннадцать")]
+        [TestCase(15, "пятнадцать")]
+        [TestCase(20, "двадцать")]
+        [TestCase(100, "сто")]
+        [TestCase(200, "двести")]
+        [TestCase(999, "девятьсот девяносто девять")]
+        [TestCase(5000, "пять тысяч")]
+        public void Russian(long number, string expected) => Check(number, Language.Russian, expected);
+
+        [TestCase(0, "Нуль")]
+        [TestCase(3, "Три")]
+        [TestCase(11, "Одинадцять")]
+        [TestCase(20, "Двадцять")]
+        [TestCase(100, "Сто")]
+        [TestCase(999, "Дев'ятсот Дев'яносто Дев'ять")]
+        [TestCase(5000, "П'ять тисяч")]
+        public void Ukrainian(long number, string expected) => Check(number, Language.Ukrainian, expected);
+
+        [TestCase(0, "нуль")]
+        [TestCase(3, "тры")]
+        [TestCase(11, "адзінаццаць")]
+        [TestCase(20, "дваццаць")]
+        [TestCase(100, "сто")]
+        [TestCase(200, "дзвесце")]
+        [TestCase(999, "дзевяцьсот дзевяноста дзевяць")]
+        [TestCase(5000, "пяць тысяч")]
+        public void Belarusian(long number, string expected) => Check(number, Language.Belarusian, expected);
+
+        [TestCase(0, "нула")]
+        [TestCase(3, "три")]
+        [TestCase(11, "единадесет")]
+        [TestCase(20, "двадесет")]
+        [TestCase(100, "сто")]
+        [TestCase(999, "деветстотин деветдесет и девет")]
+        [TestCase(1000, "хиляда")]
+        [TestCase(5000, "пет хиляди")]
+        public void Bulgarian(long number, string expected) => Check(number, Language.Bulgarian, expected);
+
+        [TestCase(0, "Zero")]
+        [TestCase(1, "Jeden")]
+        [TestCase(11, "Jedenaście")]
+        [TestCase(20, "Dwadzieścia")]
+        [TestCase(21, "Dwadzieścia Jeden")]
+        [TestCase(42, "Czterdzieści Dwa")]
+        [TestCase(100, "Sto")]
+        [TestCase(200, "Dwieście")]
+        [TestCase(999, "Dziewięćset Dziewięćdziesiąt Dziewięć")]
+        [TestCase(1000, "Jeden tysiąc")] // capitalisation is inconsistent: units are capitalised, scales are not
+        [TestCase(5000, "Pięć tysięcy")]
+        [TestCase(41000, "Czterdzieści Jeden tysięcy")]
+        [TestCase(1000000, "Jeden milion")]
+        public void Polish(long number, string expected) => Check(number, Language.Polish, expected);
+
+        [TestCase(0, "ዜሮ")]
+        [TestCase(1, "አንድ")]
+        [TestCase(11, "አስራ አንድ")]
+        [TestCase(20, "ሀያ")]
+        [TestCase(100, "አንድ መቶ")]
+        [TestCase(999, "ዘጠኝ መቶ ዘጠና ዘጠኝ")]
+        [TestCase(1000, "አንድ ሺህ")]
+        [TestCase(1000000, "አንድ ሚሊዮን")]
+        public void Amharic(long number, string expected) => Check(number, Language.Amharic, expected);
+    }
+}

--- a/src/Nut.Tests/ToTextTestBase.cs
+++ b/src/Nut.Tests/ToTextTestBase.cs
@@ -6,7 +6,7 @@
         {
             var moneyText = number.ToText(currency, lang).ToLower();
 
-            Assert.AreEqual(expectedText, moneyText);
+            Assert.That(moneyText, Is.EqualTo(expectedText));
         }
     }
 }

--- a/src/Nut.Tests/Unity.cs
+++ b/src/Nut.Tests/Unity.cs
@@ -10,7 +10,7 @@
         {
             var moneyText = number.ToText(currency, lang).ToLower();
 
-            Assert.AreEqual(expectedText, moneyText);
+            Assert.That(moneyText, Is.EqualTo(expectedText));
         }
     }
 }


### PR DESCRIPTION
Step 1 of cleaning up the library: write down what it does today, before changing any of it. 26 tests → 196.

Everything here was reproduced against the library first — no finding is from reading alone.

## Two files

**`NumberBaseline.cs`** — plain-number output for all 12 languages. Cases that are linguistically wrong are pinned as-is with a `// BUG:` note, so fixing one fails its test on purpose.

**`KnownDefects.cs`** — defects that reproduce today, each asserting the *wrong* result deliberately. The suite stays green now; the day someone fixes a defect, its test fails and must be rewritten as the correct expectation.

## What the tests found

| Defect | Effect |
|---|---|
| **Shared-table mutation in 4 converters** | The Slavic converters write gender into the singleton's word table and never restore it. `ToText(long)` returns whatever the previous conversion left behind — same input, different output. **17 938 of 50 000 concurrent conversions came out wrong** ("одна рубль"). |
| **Culture constants dead on int overloads** | `Extentions.cs:117` lowercases the language, but `Culture.*` are mixed case. All 13 return `""`. `101.ToText("en-US")` → empty, `101L.ToText("en-US")` → works. |
| **Negative numbers** | `(-5).ToText("en")` → `""`. Worse on money: `(-41.5m)` → `"dollar fifty cents"` — the 41 and the sign are both gone, and it still looks like a valid amount. |
| **Third decimal place** | `123.456m` USD → `"four hundred fifty six cents"`. No trim, no rounding. |
| **Russian / Belarusian thousands** | masculine where the noun is feminine — this is issue #25. |
| **Ukrainian millions** | inverted: its table is feminine-first, so thousands are right and millions are wrong. |
| **Bulgarian** | `1.ToText("bg")` → `""`; `1m.ToText("bgn","bg")` → `"лев и нула стотинки"`, the count simply missing. |
| **Uppercase currency** | `41m.ToText("USD","en")` → `""`. |
| **Over-limit guard** | throws bare `Exception`. |

Issue #25 and PR #28 turn out to be one instance of a wider problem: the same defect exists in Belarusian, and Ukrainian has it in the opposite direction. Merging #28 as-is would have fixed one of three.

## Not covered

Amharic wording is pinned but not verified — I cannot judge it. French, German, Spanish and Portuguese `// BUG:` notes still need a source check before anyone acts on them.