### PR TITLE
fix: remove shared mutable state from the Slavic converters

### DIFF
--- a/src/Nut.Tests/ConverterIsolation.cs
+++ b/src/Nut.Tests/ConverterIsolation.cs
@@ -1,0 +1,62 @@
+using System.Collections.Concurrent;
+using System.Threading.Tasks;
+
+namespace Nut.Tests
+{
+    /// <summary>
+    /// The four Slavic converters pick gendered forms per conversion. They used to do that
+    /// by writing into the singleton's shared word table, which leaked into the next call
+    /// and corrupted concurrent ones — 17938 of 50000 parallel conversions came back wrong.
+    /// These tests fail if that shared state ever comes back.
+    /// </summary>
+    [TestFixture]
+    public class ConverterIsolation
+    {
+        [TestCase(Language.Russian, Currency.RUB, Currency.UAH)]
+        [TestCase(Language.Ukrainian, Currency.UAH, Currency.RUB)]
+        [TestCase(Language.Belarusian, Currency.BYN, Currency.UAH)]
+        [TestCase(Language.Bulgarian, Currency.BGN, Currency.RUB)]
+        public void PlainNumbersDoNotChangeAfterAMoneyConversion(string lang, string a, string b)
+        {
+            var before = 1L.ToText(lang) + "|" + 2L.ToText(lang);
+
+            1m.ToText(a, lang);
+            2m.ToText(b, lang);
+            1m.ToText(b, lang);
+
+            Assert.That(1L.ToText(lang) + "|" + 2L.ToText(lang), Is.EqualTo(before));
+        }
+
+        [TestCase(Language.Russian, Currency.RUB, Currency.UAH)]
+        [TestCase(Language.Belarusian, Currency.BYN, Currency.UAH)]
+        public void MoneyConversionsDoNotAffectEachOther(string lang, string a, string b)
+        {
+            var first = 1m.ToText(a, lang);
+            var second = 1m.ToText(b, lang);
+
+            Assert.That(1m.ToText(a, lang), Is.EqualTo(first));
+            Assert.That(1m.ToText(b, lang), Is.EqualTo(second));
+            Assert.That(first, Is.Not.EqualTo(second), "these two currencies should differ");
+        }
+
+        [Test]
+        public void ConcurrentConversionsAgreeWithSequentialOnes()
+        {
+            var ruble = 1m.ToText(Currency.RUB, Language.Russian);
+            var hryvnia = 1m.ToText(Currency.UAH, Language.Russian);
+
+            var wrong = new ConcurrentBag<string>();
+            Parallel.For(0, 20000, i =>
+            {
+                var useRuble = i % 2 == 0;
+                var actual = useRuble
+                    ? 1m.ToText(Currency.RUB, Language.Russian)
+                    : 1m.ToText(Currency.UAH, Language.Russian);
+                var expected = useRuble ? ruble : hryvnia;
+                if (actual != expected) wrong.Add(actual);
+            });
+
+            Assert.That(wrong, Is.Empty);
+        }
+    }
+}

--- a/src/Nut.Tests/ConverterIsolation.cs
+++ b/src/Nut.Tests/ConverterIsolation.cs
@@ -39,21 +39,30 @@ namespace Nut.Tests
             Assert.That(first, Is.Not.EqualTo(second), "these two currencies should differ");
         }
 
-        [Test]
-        public void ConcurrentConversionsAgreeWithSequentialOnes()
+        /// <summary>
+        /// 21000 and 22000 go through the scale-prefix path, which is where the gendered
+        /// forms and — in Bulgarian — the mutable textType field are read.
+        /// </summary>
+        [TestCase(Language.Russian, Currency.RUB, Currency.UAH)]
+        [TestCase(Language.Ukrainian, Currency.UAH, Currency.RUB)]
+        [TestCase(Language.Belarusian, Currency.BYN, Currency.UAH)]
+        [TestCase(Language.Bulgarian, Currency.BGN, Currency.RUB)]
+        public void ConcurrentConversionsAgreeWithSequentialOnes(string lang, string a, string b)
         {
-            var ruble = 1m.ToText(Currency.RUB, Language.Russian);
-            var hryvnia = 1m.ToText(Currency.UAH, Language.Russian);
+            var expected = new[]
+            {
+                21000m.ToText(a, lang), 22000m.ToText(a, lang),
+                21000m.ToText(b, lang), 22000m.ToText(b, lang),
+            };
 
             var wrong = new ConcurrentBag<string>();
             Parallel.For(0, 20000, i =>
             {
-                var useRuble = i % 2 == 0;
-                var actual = useRuble
-                    ? 1m.ToText(Currency.RUB, Language.Russian)
-                    : 1m.ToText(Currency.UAH, Language.Russian);
-                var expected = useRuble ? ruble : hryvnia;
-                if (actual != expected) wrong.Add(actual);
+                var slot = i % 4;
+                var currency = slot < 2 ? a : b;
+                var amount = slot % 2 == 0 ? 21000m : 22000m;
+                var actual = amount.ToText(currency, lang);
+                if (actual != expected[slot]) wrong.Add($"{lang}/{currency}/{amount}: {actual}");
             });
 
             Assert.That(wrong, Is.Empty);

--- a/src/Nut.Tests/KnownDefects.cs
+++ b/src/Nut.Tests/KnownDefects.cs
@@ -49,29 +49,6 @@ namespace Nut.Tests
             Assert.That(41m.ToText("usd", Language.English), Is.Not.Empty);
         }
 
-        /// <summary>
-        /// The Slavic converters assign into the singleton's shared word table to pick a
-        /// gender, and never restore it. A plain ToText(long) carries no currency context
-        /// yet still returns whatever the previous conversion left behind, so the same
-        /// input produces different output depending on call order. Under concurrent load
-        /// this also corrupts results outright.
-        /// </summary>
-        [Test]
-        public void RussianOneDependsOnThePreviousCurrencyConversion()
-        {
-            1m.ToText(Currency.USD, Language.Russian); // default branch leaves masculine
-            var afterDollar = 1L.ToText(Language.Russian);
-
-            1m.ToText(Currency.RUB, Language.Russian); // sub-unit pass leaves feminine
-            var afterRuble = 1L.ToText(Language.Russian);
-
-            Assert.That(afterDollar, Is.EqualTo("один"));
-            Assert.That(afterRuble, Is.EqualTo("одна"));
-            Assert.That(afterDollar, Is.Not.EqualTo(afterRuble), "same call, different answers");
-
-            1m.ToText(Currency.USD, Language.Russian); // leave the table as we found it
-        }
-
         /// <summary>Thousands take the feminine form in these languages; millions stay masculine.</summary>
         [Test]
         public void RussianThousandsUseTheMasculineFormInstead()

--- a/src/Nut.Tests/NumberBaseline.cs
+++ b/src/Nut.Tests/NumberBaseline.cs
@@ -127,43 +127,77 @@ namespace Nut.Tests
         public void Turkish(long number, string expected) => Check(number, Language.Turkish, expected);
 
         [TestCase(0, "ноль")]
+        [TestCase(1, "один")]
+        [TestCase(2, "два")]
         [TestCase(3, "три")]
         [TestCase(11, "одиннадцать")]
         [TestCase(15, "пятнадцать")]
         [TestCase(20, "двадцать")]
+        [TestCase(21, "двадцать один")]
+        [TestCase(42, "сорок два")]
         [TestCase(100, "сто")]
+        [TestCase(101, "сто один")]
         [TestCase(200, "двести")]
         [TestCase(999, "девятьсот девяносто девять")]
+        [TestCase(1000, "один тысяча")] // BUG: тысяча is feminine -> "одна тысяча"
+        [TestCase(2000, "два тысячи")] // BUG: -> "две тысячи"
         [TestCase(5000, "пять тысяч")]
+        [TestCase(41000, "сорок один тысяча")] // BUG: issue #25 -> "сорок одна тысяча"
+        [TestCase(1000000, "один миллион")] // correct: миллион is masculine
+        [TestCase(2000000, "два миллиона")]
+        [TestCase(1000000000, "один миллиард")]
         public void Russian(long number, string expected) => Check(number, Language.Russian, expected);
 
+        // Ukrainian's table is feminine-first, so bare numbers come out feminine and
+        // millions inherit that. Capitalisation of units is also inconsistent with scales.
         [TestCase(0, "Нуль")]
+        [TestCase(1, "Одна")] // BUG: the bare numeral is masculine -> "один"
+        [TestCase(2, "Дві")] // BUG: -> "два"
         [TestCase(3, "Три")]
         [TestCase(11, "Одинадцять")]
         [TestCase(20, "Двадцять")]
+        [TestCase(21, "Двадцять Одна")] // BUG: -> "двадцять один"
         [TestCase(100, "Сто")]
         [TestCase(999, "Дев'ятсот Дев'яносто Дев'ять")]
+        [TestCase(1000, "Одна тисяча")] // correct: тисяча is feminine
+        [TestCase(2000, "Дві тисячі")]
         [TestCase(5000, "П'ять тисяч")]
+        [TestCase(41000, "Сорок Одна тисяча")]
+        [TestCase(1000000, "Одна мільйон")] // BUG: мільйон is masculine -> "один мільйон"
+        [TestCase(1000000000, "Одна мільярд")] // BUG: -> "один мільярд"
         public void Ukrainian(long number, string expected) => Check(number, Language.Ukrainian, expected);
 
         [TestCase(0, "нуль")]
+        [TestCase(1, "адзін")]
+        [TestCase(2, "два")]
         [TestCase(3, "тры")]
         [TestCase(11, "адзінаццаць")]
         [TestCase(20, "дваццаць")]
+        [TestCase(21, "дваццаць адзін")]
         [TestCase(100, "сто")]
         [TestCase(200, "дзвесце")]
         [TestCase(999, "дзевяцьсот дзевяноста дзевяць")]
+        [TestCase(1000, "адзін тысяча")] // BUG: тысяча is feminine -> "адна тысяча"
+        [TestCase(2000, "два тысячы")] // BUG: -> "дзве тысячы"
         [TestCase(5000, "пяць тысяч")]
+        [TestCase(41000, "сорак адзін тысяча")] // BUG: same defect as Russian -> "сорак адна тысяча"
+        [TestCase(1000000, "адзін мільён")] // correct: мільён is masculine
         public void Belarusian(long number, string expected) => Check(number, Language.Belarusian, expected);
 
         [TestCase(0, "нула")]
+        [TestCase(2, "два")]
         [TestCase(3, "три")]
         [TestCase(11, "единадесет")]
         [TestCase(20, "двадесет")]
+        [TestCase(21, "двадесет и един")]
         [TestCase(100, "сто")]
+        [TestCase(101, "сто и един")]
         [TestCase(999, "деветстотин деветдесет и девет")]
         [TestCase(1000, "хиляда")]
+        [TestCase(2000, "две хиляди")]
         [TestCase(5000, "пет хиляди")]
+        [TestCase(41000, "четиридесет и една хиляди")]
+        [TestCase(2000000, "две милиона")] // BUG: милион is masculine -> "два милиона"
         public void Bulgarian(long number, string expected) => Check(number, Language.Bulgarian, expected);
 
         [TestCase(0, "Zero")]

--- a/src/Nut/TextConverters/BaseConverter.cs
+++ b/src/Nut/TextConverters/BaseConverter.cs
@@ -20,6 +20,18 @@ namespace Nut.TextConverters
       ScaleTexts = new Dictionary<long, string[]>();
     }
 
+    /// <summary>
+    /// Shares another converter's word tables instead of rebuilding them. Used by the
+    /// converters that need per-conversion state (gendered numerals) so they can keep that
+    /// state on a short-lived instance without paying to rebuild the tables. The tables are
+    /// shared, so a subclass using this must never write into them.
+    /// </summary>
+    protected BaseConverter(BaseConverter template)
+    {
+      NumberTexts = template.NumberTexts;
+      ScaleTexts = template.ScaleTexts;
+    }
+
     public abstract string CultureName { get; }
 
     public virtual string ToText(long num, GenderGroup genderGroup = GenderGroup.None)

--- a/src/Nut/TextConverters/BelarusianConverter.cs
+++ b/src/Nut/TextConverters/BelarusianConverter.cs
@@ -17,26 +17,56 @@ namespace Nut.TextConverters
             Initialize();
         }
 
-        protected override string ToText(long num, CurrencyModel currencyModel, bool isMainUnit)
+        // Set only on the short-lived per-conversion instance; null on the shared singleton.
+        private string _one;
+        private string _two;
+
+        private BelarusianConverter(BelarusianConverter template, CurrencyModel currencyModel, bool isMainUnit)
+            : base(template)
         {
             switch (currencyModel.Currency)
             {
                 case Currency.BYN:
                 case Currency.RUB:
                 case Currency.EUR:
-                    NumberTexts[1][0] = isMainUnit ? "адзін" : "адна";
-                    NumberTexts[2][0] = isMainUnit ? "два" : "дзве";
+                    _one = isMainUnit ? "адзін" : "адна";
+                    _two = isMainUnit ? "два" : "дзве";
                     break;
                 case Currency.UAH:
-                    NumberTexts[1][0] = "адна";
-                    NumberTexts[2][0] = "дзве";
+                    _one = "адна";
+                    _two = "дзве";
                     break;
                 default:
-                    NumberTexts[1][0] = "адзін";
-                    NumberTexts[2][0] = "два";
+                    _one = "адзін";
+                    _two = "два";
                     break;
             }
-            return ToText(num);
+        }
+
+        protected override string ToText(long num, CurrencyModel currencyModel, bool isMainUnit)
+        {
+            // Gendered forms are per-conversion; see RussianConverter for why this is not
+            // written into the shared singleton.
+            return new BelarusianConverter(this, currencyModel, isMainUnit).ToText(num);
+        }
+
+        protected override void AppendUnits(long num, StringBuilder builder)
+        {
+            if (!AppendGendered(num, builder)) base.AppendUnits(num, builder);
+        }
+
+        // The scale-prefix path reads the same entries, so it needs the same treatment.
+        protected override void AppendUnitsForAdditional(long num, StringBuilder builder)
+        {
+            if (!AppendGendered(num, builder)) base.AppendUnitsForAdditional(num, builder);
+        }
+
+        private bool AppendGendered(long num, StringBuilder builder)
+        {
+            var word = num == 1 ? _one : num == 2 ? _two : null;
+            if (word == null) return false;
+            builder.AppendFormat("{0} ", word);
+            return true;
         }
 
         protected override long Append(long num, long scale, StringBuilder builder)

--- a/src/Nut/TextConverters/BulgarianConverter.cs
+++ b/src/Nut/TextConverters/BulgarianConverter.cs
@@ -17,7 +17,11 @@ namespace Nut.TextConverters
             Initialize();
         }
 
-        protected override string ToText(long num, CurrencyModel currencyModel, bool isMainUnit)
+        // Set only on the short-lived per-conversion instance; null on the shared singleton.
+        private string _two;
+
+        private BulgarianConverter(BulgarianConverter template, CurrencyModel currencyModel)
+            : base(template)
         {
             switch (currencyModel.Currency)
             {
@@ -25,13 +29,20 @@ namespace Nut.TextConverters
                 case Currency.EUR:
                 case Currency.RUB:
                 case Currency.UAH:
-                    NumberTexts[2][0] = "две";
+                    _two = "две";
                     break;
                 default:
-                    NumberTexts[2][0] = "два";
+                    _two = "два";
                     break;
             }
-            return ToText(num);
+        }
+
+        protected override string ToText(long num, CurrencyModel currencyModel, bool isMainUnit)
+        {
+            // Gendered forms are per-conversion; see RussianConverter for why this is not
+            // written into the shared singleton. This also gives textType, which Append
+            // rewrites as it walks the number, an instance of its own.
+            return new BulgarianConverter(this, currencyModel).ToText(num);
         }
 
         protected override long Append(long num, long scale, StringBuilder builder)
@@ -106,7 +117,10 @@ namespace Nut.TextConverters
                 if (builder.ToString().Trim().Length > 0)
                     builder.Append("и ");
                 var targetType = Math.Min(NumberTexts[num].Length - 1, textType);
-                builder.AppendFormat("{0} ", NumberTexts[num][targetType]);
+                // _two stands in for entry 2's default form, which used to be overwritten
+                // in the shared table per currency.
+                builder.AppendFormat("{0} ",
+                    num == 2 && targetType == 0 && _two != null ? _two : NumberTexts[num][targetType]);
             }
         }
 
@@ -114,7 +128,10 @@ namespace Nut.TextConverters
         {
             if (num != 0 && builder.ToString().Trim().Length > 0)
                 builder.Append("и ");
-            base.AppendUnitsForAdditional(num, builder);
+            // Same substitution as AppendUnits: entry 2's default form used to be
+            // overwritten in the shared table per currency.
+            if (num == 2 && _two != null) builder.AppendFormat("{0} ", _two);
+            else base.AppendUnitsForAdditional(num, builder);
         }
 
         private byte GetTextType(long num)

--- a/src/Nut/TextConverters/RussianConverter.cs
+++ b/src/Nut/TextConverters/RussianConverter.cs
@@ -17,26 +17,57 @@ namespace Nut.TextConverters
       Initialize();
     }
 
-    protected override string ToText(long num, CurrencyModel currencyModel, bool isMainUnit)
+    // Set only on the short-lived per-conversion instance; null on the shared singleton.
+    private string _one;
+    private string _two;
+
+    private RussianConverter(RussianConverter template, CurrencyModel currencyModel, bool isMainUnit)
+      : base(template)
     {
       switch (currencyModel.Currency)
       {
         case Currency.BYN:
         case Currency.RUB:
         case Currency.EUR:
-          NumberTexts[1][0] = isMainUnit ? "один" : "одна";
-          NumberTexts[2][0] = isMainUnit ? "два" : "две";
+          _one = isMainUnit ? "один" : "одна";
+          _two = isMainUnit ? "два" : "две";
           break;
         case Currency.UAH:
-          NumberTexts[1][0] = "одна";
-          NumberTexts[2][0] = "две";
+          _one = "одна";
+          _two = "две";
           break;
         default:
-          NumberTexts[1][0] = "один";
-          NumberTexts[2][0] = "два";
+          _one = "один";
+          _two = "два";
           break;
       }
-      return ToText(num);
+    }
+
+    protected override string ToText(long num, CurrencyModel currencyModel, bool isMainUnit)
+    {
+      // One and two agree in gender with the unit being counted, so the choice differs per
+      // conversion. Keep it on a throwaway instance: writing it into the singleton's word
+      // table would leak into the next call and corrupt concurrent ones.
+      return new RussianConverter(this, currencyModel, isMainUnit).ToText(num);
+    }
+
+    protected override void AppendUnits(long num, StringBuilder builder)
+    {
+      if (!AppendGendered(num, builder)) base.AppendUnits(num, builder);
+    }
+
+    // The scale-prefix path reads the same entries, so it needs the same treatment.
+    protected override void AppendUnitsForAdditional(long num, StringBuilder builder)
+    {
+      if (!AppendGendered(num, builder)) base.AppendUnitsForAdditional(num, builder);
+    }
+
+    private bool AppendGendered(long num, StringBuilder builder)
+    {
+      var word = num == 1 ? _one : num == 2 ? _two : null;
+      if (word == null) return false;
+      builder.AppendFormat("{0} ", word);
+      return true;
     }
 
     protected override long Append(long num, long scale, StringBuilder builder)

--- a/src/Nut/TextConverters/UkrainianConverter.cs
+++ b/src/Nut/TextConverters/UkrainianConverter.cs
@@ -20,22 +20,52 @@ namespace Nut.TextConverters
       Initialize();
     }
 
-    protected override string ToText(long num, CurrencyModel currencyModel, bool isMainUnit)
+    // Set only on the short-lived per-conversion instance; null on the shared singleton.
+    private string _one;
+    private string _two;
+
+    private UkrainianConverter(UkrainianConverter template, CurrencyModel currencyModel, bool isMainUnit)
+      : base(template)
     {
       switch (currencyModel.Currency)
       {
         case Currency.BYN:
         case Currency.RUB:
         case Currency.EUR:
-          NumberTexts[1][0] = isMainUnit ? "Один" : "Одна";
-          NumberTexts[2][0] = isMainUnit ? "Два" : "Дві";
+          _one = isMainUnit ? "Один" : "Одна";
+          _two = isMainUnit ? "Два" : "Дві";
           break;
         default:
-          NumberTexts[1][0] = "Одна";
-          NumberTexts[2][0] = "Дві";
+          _one = "Одна";
+          _two = "Дві";
           break;
       }
-      return ToText(num);
+    }
+
+    protected override string ToText(long num, CurrencyModel currencyModel, bool isMainUnit)
+    {
+      // Gendered forms are per-conversion; see RussianConverter for why this is not
+      // written into the shared singleton.
+      return new UkrainianConverter(this, currencyModel, isMainUnit).ToText(num);
+    }
+
+    protected override void AppendUnits(long num, StringBuilder builder)
+    {
+      if (!AppendGendered(num, builder)) base.AppendUnits(num, builder);
+    }
+
+    // The scale-prefix path reads the same entries, so it needs the same treatment.
+    protected override void AppendUnitsForAdditional(long num, StringBuilder builder)
+    {
+      if (!AppendGendered(num, builder)) base.AppendUnitsForAdditional(num, builder);
+    }
+
+    private bool AppendGendered(long num, StringBuilder builder)
+    {
+      var word = num == 1 ? _one : num == 2 ? _two : null;
+      if (word == null) return false;
+      builder.AppendFormat("{0} ", word);
+      return true;
     }
 
     protected override long Append(long num, long scale, StringBuilder builder)


### PR DESCRIPTION
Step 2a. Removes the shared-state defect **without changing any output** — including the linguistic defects, which are step 2b.

## The problem

Four converters (Russian, Ukrainian, Belarusian, Bulgarian) are singletons that wrote gendered word forms into their shared `NumberTexts` dictionary before each conversion and never restored it:

```csharp
NumberTexts[1][0] = isMainUnit ? "один" : "одна";   // on the singleton
```

- `ToText(long)` returned whatever the previous conversion left behind — same input, different output.
- Concurrent conversions overwrote each other: **17 938 of 50 000 parallel calls came back wrong** ("одна рубль" — feminine numeral, masculine noun).

Bulgarian also kept a mutable `textType` field that `Append` rewrites as it walks the number, with the same race.

## The fix

Each of the four builds a short-lived instance per conversion holding the chosen forms in fields, sharing the word tables read-only. Nothing writes to shared state any more.

Both `AppendUnits` **and** `AppendUnitsForAdditional` consult those fields. The second path matters: the old mutation reached it too, and missing it silently changed 44 outputs.

## Evidence that behaviour is unchanged

12 languages × 11 currencies × 32 amounts, plus 26 plain numbers per language — **4 536 conversions, byte-identical before and after**.

That exhaustive diff is what caught the `AppendUnitsForAdditional` gap. The 234-test suite passed while those 44 outputs were wrong, because no test covered `ru`+`uah`+`1000`. Worth remembering for the remaining steps.

## Cost

Sharing the tables instead of copying them keeps it flat:

| | before | after |
|---|---|---|
| `41000m.ToText(rub, ru)` | 0.79 µs | 0.80 µs |

(A first attempt that called `Initialize()` per conversion cost 3.14 µs; a shallow dictionary copy 2.37 µs. Neither was needed.)

## Tests

`ConverterIsolation` replaces the defect test that asserted the leak existed. It checks that plain numbers survive money conversions, that currencies do not affect each other, and that 20 000 parallel conversions all agree with the sequential result.

`NumberBaseline` gains the Slavic `1`/`2` cases that had to be left out before — they are finally deterministic enough to assert. They are still linguistically wrong and marked `// BUG:`; step 2b fixes them and issue #25 with them.