### PR TITLE
docs: add Bulgarian to the package description

### DIFF
--- a/src/Nut/Nut.csproj
+++ b/src/Nut/Nut.csproj
@@ -8,7 +8,7 @@
     <Description>Number To Text Converter
 Money To Text Converter
 
-Supported Languages: English, Spanish, French, German, Turkish, Russian, Ukrainian, Amharic, Polish, Belarussian, Portuguese.
+Supported Languages: English, Spanish, French, German, Turkish, Russian, Ukrainian, Bulgarian, Amharic, Polish, Belarussian, Portuguese.
 
 Supported Currencies: EUR, USD, RUB, TRY, UAH, BGN, ETB, PLN, BYN, ARS, BRL.
 


### PR DESCRIPTION
One word. Bulgarian has been supported since 2017 but is missing from the `Description` NuGet renders on the package page — the same omission the README had for German.

Caught by unpacking a dry-run `dotnet pack` before tagging v3.5.0.