### PR TITLE
fix: agree gender with the scale word, not the currency (closes #25)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,25 @@ version rather than a complete list.
 Work in progress on the linguistic defects recorded in `Nut.Tests/KnownDefects.cs`. These
 change the produced text, so they are being collected for 4.0.0 rather than a minor release.
 
+### Fixed
+
+- **Russian and Belarusian: the count now agrees with the scale word rather than the
+  currency** ([#25](https://github.com/emrahyumuk/NUT-number-to-text/issues/25)).
+  `тысяча` is feminine and `миллион` is masculine, and both can occur in one amount.
+
+  | Amount | Before | After |
+  | --- | --- | --- |
+  | `41000 RUB` | сорок **один** тысяча рублей | сорок **одна** тысяча рублей |
+  | `42000 RUB` | сорок **два** тысячи рублей | сорок **две** тысячи рублей |
+  | `1000000 UAH` in Russian | **одна** миллион гривень | **один** миллион гривень |
+  | `41000 BYN` | сорак **адзін** тысяча | сорак **адна** тысяча |
+
+  128 of 4536 checked conversions change; no other language is affected.
+
+### Added
+
+- `Currency.RUR` as an alias for `Currency.RUB`, mirroring how `tl` maps to `try`.
+
 ## [3.5.0] - 2026-07-28
 
 Output is byte-for-byte identical to 3.4.1 in all 12 languages. The fix below is about

--- a/src/Nut.Tests/GenderAgreement.cs
+++ b/src/Nut.Tests/GenderAgreement.cs
@@ -1,0 +1,61 @@
+namespace Nut.Tests
+{
+    /// <summary>
+    /// The count in front of a scale word agrees with that scale word, not with the
+    /// currency: тысяча is feminine, миллион is masculine, and both appear in the same
+    /// amount. Closes issue #25.
+    /// </summary>
+    [TestFixture]
+    public class GenderAgreement
+    {
+        [TestCase(1000, "одна тысяча рублей ноль копеек")]
+        [TestCase(2000, "две тысячи рублей ноль копеек")]
+        [TestCase(21000, "двадцать одна тысяча рублей ноль копеек")]
+        [TestCase(22000, "двадцать две тысячи рублей ноль копеек")]
+        [TestCase(41000, "сорок одна тысяча рублей ноль копеек")]
+        [TestCase(42000, "сорок две тысячи рублей ноль копеек")]
+        [TestCase(1000000, "один миллион рублей ноль копеек")] // миллион stays masculine
+        [TestCase(2000000, "два миллиона рублей ноль копеек")]
+        [TestCase(1001, "одна тысяча один рубль ноль копеек")] // feminine before тысяча, masculine before рубль
+        [TestCase(2002, "две тысячи два рубля ноль копеек")]
+        public void RussianRuble(decimal amount, string expected)
+        {
+            Assert.That(amount.ToText(Currency.RUB, Language.Russian), Is.EqualTo(expected));
+        }
+
+        /// <summary>The scale word decides, so a feminine currency does not change it.</summary>
+        [TestCase(41000, "сорок одна тысяча гривень ноль копеек")]
+        [TestCase(1000000, "один миллион гривень ноль копеек")]
+        public void RussianHryvnia(decimal amount, string expected)
+        {
+            Assert.That(amount.ToText(Currency.UAH, Language.Russian), Is.EqualTo(expected));
+        }
+
+        [TestCase(1000, "адна тысяча беларускіх рублёў нуль капеек")]
+        [TestCase(2000, "дзве тысячы беларускіх рублёў нуль капеек")]
+        [TestCase(41000, "сорак адна тысяча беларускіх рублёў нуль капеек")]
+        [TestCase(42000, "сорак дзве тысячы беларускіх рублёў нуль капеек")]
+        [TestCase(1000000, "адзін мільён беларускіх рублёў нуль капеек")] // мільён stays masculine
+        public void BelarusianRuble(decimal amount, string expected)
+        {
+            Assert.That(amount.ToText(Currency.BYN, Language.Belarusian), Is.EqualTo(expected));
+        }
+
+        [TestCase(1000, "одна тысяча")]
+        [TestCase(41000, "сорок одна тысяча")]
+        [TestCase(1000000, "один миллион")]
+        public void RussianPlainNumbersAgreeToo(long number, string expected)
+        {
+            Assert.That(number.ToText(Language.Russian), Is.EqualTo(expected));
+        }
+
+        /// <summary>"rur" is a widely used alias for the Russian ruble, like "tl" for "try".</summary>
+        [Test]
+        public void RurIsAnAliasForRub()
+        {
+            Assert.That(41000m.ToText(Currency.RUR, Language.Russian),
+                Is.EqualTo(41000m.ToText(Currency.RUB, Language.Russian)));
+            Assert.That("rur", Is.EqualTo(Currency.RUR));
+        }
+    }
+}

--- a/src/Nut.Tests/KnownDefects.cs
+++ b/src/Nut.Tests/KnownDefects.cs
@@ -49,23 +49,6 @@ namespace Nut.Tests
             Assert.That(41m.ToText("usd", Language.English), Is.Not.Empty);
         }
 
-        /// <summary>Thousands take the feminine form in these languages; millions stay masculine.</summary>
-        [Test]
-        public void RussianThousandsUseTheMasculineFormInstead()
-        {
-            Assert.That(41000m.ToText(Currency.RUB, Language.Russian),
-                Is.EqualTo("сорок один тысяча рублей ноль копеек")); // "сорок одна тысяча"
-            Assert.That(42000m.ToText(Currency.RUB, Language.Russian),
-                Is.EqualTo("сорок два тысячи рублей ноль копеек")); // "сорок две тысячи"
-        }
-
-        [Test]
-        public void BelarusianHasTheSameThousandsDefect()
-        {
-            Assert.That(41000m.ToText(Currency.BYN, Language.Belarusian),
-                Is.EqualTo("сорак адзін тысяча беларускіх рублёў нуль капеек")); // "сорак адна тысяча"
-        }
-
         /// <summary>Ukrainian is wrong in the opposite direction: its table is feminine-first,
         /// so thousands come out right and millions come out feminine. тисяча is feminine,
         /// мільйон is masculine, so the correct forms are "одна тисяча" and "один мільйон".</summary>

--- a/src/Nut.Tests/NumberBaseline.cs
+++ b/src/Nut.Tests/NumberBaseline.cs
@@ -139,10 +139,10 @@ namespace Nut.Tests
         [TestCase(101, "сто один")]
         [TestCase(200, "двести")]
         [TestCase(999, "девятьсот девяносто девять")]
-        [TestCase(1000, "один тысяча")] // BUG: тысяча is feminine -> "одна тысяча"
-        [TestCase(2000, "два тысячи")] // BUG: -> "две тысячи"
+        [TestCase(1000, "одна тысяча")]
+        [TestCase(2000, "две тысячи")]
         [TestCase(5000, "пять тысяч")]
-        [TestCase(41000, "сорок один тысяча")] // BUG: issue #25 -> "сорок одна тысяча"
+        [TestCase(41000, "сорок одна тысяча")]
         [TestCase(1000000, "один миллион")] // correct: миллион is masculine
         [TestCase(2000000, "два миллиона")]
         [TestCase(1000000000, "один миллиард")]
@@ -177,10 +177,10 @@ namespace Nut.Tests
         [TestCase(100, "сто")]
         [TestCase(200, "дзвесце")]
         [TestCase(999, "дзевяцьсот дзевяноста дзевяць")]
-        [TestCase(1000, "адзін тысяча")] // BUG: тысяча is feminine -> "адна тысяча"
-        [TestCase(2000, "два тысячы")] // BUG: -> "дзве тысячы"
+        [TestCase(1000, "адна тысяча")]
+        [TestCase(2000, "дзве тысячы")]
         [TestCase(5000, "пяць тысяч")]
-        [TestCase(41000, "сорак адзін тысяча")] // BUG: same defect as Russian -> "сорак адна тысяча"
+        [TestCase(41000, "сорак адна тысяча")]
         [TestCase(1000000, "адзін мільён")] // correct: мільён is masculine
         public void Belarusian(long number, string expected) => Check(number, Language.Belarusian, expected);
 

--- a/src/Nut/Constants.cs
+++ b/src/Nut/Constants.cs
@@ -44,6 +44,8 @@
         internal const string TL = "tl";
         public const string EUR = "eur";
         public const string RUB = "rub";
+        /// <summary>Widely used alias for the Russian ruble; treated as <see cref="RUB"/>.</summary>
+        public const string RUR = "rur";
         public const string TRY = "try";
         public const string USD = "usd";
         public const string UAH = "uah";

--- a/src/Nut/TextConverters/BaseConverter.cs
+++ b/src/Nut/TextConverters/BaseConverter.cs
@@ -144,6 +144,7 @@ namespace Nut.TextConverters
     {
       var builder = new StringBuilder();
       if (currency == Currency.TL) currency = Currency.TRY;
+      if (currency == Currency.RUR) currency = Currency.RUB;
       var currencyModel = GetCurrencyModel(currency);
       if (currencyModel == null) return string.Empty;
       var decimalSeperator = num.ToString(CultureInfo.InvariantCulture).Contains(",") ? ',' : '.';

--- a/src/Nut/TextConverters/BelarusianConverter.cs
+++ b/src/Nut/TextConverters/BelarusianConverter.cs
@@ -55,10 +55,13 @@ namespace Nut.TextConverters
             if (!AppendGendered(num, builder)) base.AppendUnits(num, builder);
         }
 
-        // The scale-prefix path reads the same entries, so it needs the same treatment.
+        // Append only routes here for scale 1000, and the count before тысяча agrees with
+        // тысяча, which is feminine whatever currency is being counted: "сорак адна
+        // тысяча", not "сорак адзін тысяча". Entry [1] holds the feminine form.
         protected override void AppendUnitsForAdditional(long num, StringBuilder builder)
         {
-            if (!AppendGendered(num, builder)) base.AppendUnitsForAdditional(num, builder);
+            if (num == 1 || num == 2) builder.AppendFormat("{0} ", NumberTexts[num][1]);
+            else base.AppendUnitsForAdditional(num, builder);
         }
 
         private bool AppendGendered(long num, StringBuilder builder)
@@ -83,7 +86,7 @@ namespace Nut.TextConverters
                 }
                 else
                 {
-                    AppendLessThanOneThousand(baseScale, builder);
+                    AppendLessThanOneThousandForScale(baseScale, builder);
                 }
 
                 switch (textType)
@@ -109,6 +112,15 @@ namespace Nut.TextConverters
             num = AppendHundreds(num, builder);
             num = AppendTens(num, builder);
             AppendUnitsForAdditional(num, builder);
+        }
+
+        // мільён and мільярд are masculine, so their count must not pick up the currency's
+        // gender the way the trailing unit does: "адзін мільён грыўняў", not "адна мільён".
+        private void AppendLessThanOneThousandForScale(long num, StringBuilder builder)
+        {
+            num = AppendHundreds(num, builder);
+            num = AppendTens(num, builder);
+            base.AppendUnits(num, builder);
         }
 
         protected override long AppendHundreds(long num, StringBuilder builder)

--- a/src/Nut/TextConverters/RussianConverter.cs
+++ b/src/Nut/TextConverters/RussianConverter.cs
@@ -56,10 +56,13 @@ namespace Nut.TextConverters
       if (!AppendGendered(num, builder)) base.AppendUnits(num, builder);
     }
 
-    // The scale-prefix path reads the same entries, so it needs the same treatment.
+    // Append only routes here for scale 1000, and the count before тысяча agrees with
+    // тысяча, which is feminine whatever currency is being counted: "сорок одна тысяча
+    // рублей", not "сорок один тысяча рублей". Entry [1] holds the feminine form.
     protected override void AppendUnitsForAdditional(long num, StringBuilder builder)
     {
-      if (!AppendGendered(num, builder)) base.AppendUnitsForAdditional(num, builder);
+      if (num == 1 || num == 2) builder.AppendFormat("{0} ", NumberTexts[num][1]);
+      else base.AppendUnitsForAdditional(num, builder);
     }
 
     private bool AppendGendered(long num, StringBuilder builder)
@@ -84,7 +87,7 @@ namespace Nut.TextConverters
         }
         else
         {
-          AppendLessThanOneThousand(baseScale, builder);
+          AppendLessThanOneThousandForScale(baseScale, builder);
         }
 
         switch (textType)
@@ -110,6 +113,15 @@ namespace Nut.TextConverters
       num = AppendHundreds(num, builder);
       num = AppendTens(num, builder);
       AppendUnitsForAdditional(num, builder);
+    }
+
+    // миллион and миллиард are masculine, so their count must not pick up the currency's
+    // gender the way the trailing unit does: "один миллион гривень", not "одна миллион".
+    private void AppendLessThanOneThousandForScale(long num, StringBuilder builder)
+    {
+      num = AppendHundreds(num, builder);
+      num = AppendTens(num, builder);
+      base.AppendUnits(num, builder);
     }
 
     protected override long AppendHundreds(long num, StringBuilder builder)


### PR DESCRIPTION
Step 2b. **Changes produced text**, so this is for 4.0.0, not a minor release.

Closes #25. Supersedes #28.

## The rule

In Russian and Belarusian the count in front of a scale word agrees with *that word*, not with the currency. `тысяча` is feminine, `миллион` is masculine, and both can appear in the same amount:

```
1001 RUB  ->  одна тысяча один рубль
              ^feminine  ^masculine
```

## What changed

| Amount | Before | After |
|---|---|---|
| `41000 RUB` | сорок **один** тысяча рублей | сорок **одна** тысяча рублей |
| `42000 RUB` | сорок **два** тысячи рублей | сорок **две** тысячи рублей |
| `41000 BYN` | сорак **адзін** тысяча | сорак **адна** тысяча |
| `1000000 UAH` in Russian | **одна** миллион гривень | **один** миллион гривень |

Two separate paths were wrong:

1. **The thousands prefix** applied the currency's gender. It is always feminine there, so it now reads the feminine entry directly. This is the half #28 found.
2. **The millions/milliards prefix** went through `AppendUnits`, which carries the currency's gender — so a *feminine currency* produced `одна миллион`. Not in the original report; it surfaced only because the new tests pair a feminine currency with a masculine scale word.

Also adds `Currency.RUR` as an alias for `RUB`, mirroring `tl` → `try`. That is #28's second half.

## Verification

Exhaustive dump, 12 languages × 11 currencies × 32 amounts + 26 plain numbers = **4536 conversions**, diffed against master:

- **128 lines changed, all in Russian and Belarusian** (64 each). No other language touched.
- Wrong forms remaining in the new output: `один тысяча` 0, `два тысячи` 0, `одна миллион` 0, `адзін тысяча` 0, `два тысячы` 0, `адна мільён` 0.

256 tests pass. New `GenderAgreement` fixture asserts the correct forms directly, including the mixed case (`1001` → feminine then masculine) and the RUR alias.

## Not in this PR

Ukrainian and Bulgarian have related gender defects with different mechanics — Ukrainian's table is feminine-first and its `Append` routes millions where Russian routes thousands. Their `KnownDefects` entries stay until that is done separately.