### PR TITLE
fix: link Spanish scale nouns to the currency with "de"

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -132,6 +132,11 @@ change the produced text, so they are being collected for 4.0.0 rather than a mi
   Also fixes a stray trailing space in the word for fifty, which produced
   `cinquante -deux`.
 
+- **Spanish scale nouns now link to the currency with "de"**, which RAE requires:
+  `un millón de euros`, not `un millón euros`. `mil` is an adjective and takes none, so
+  `mil euros` is unchanged, and the preposition only appears when the amount ends on the
+  scale noun — `un millón quinientos mil euros` keeps none.
+
 ### Added
 
 - `Options.SubUnitTruncated`, for callers who need extra decimals dropped rather than

--- a/src/Nut.Tests/SpanishNumerals.cs
+++ b/src/Nut.Tests/SpanishNumerals.cs
@@ -1,4 +1,4 @@
-namespace Nut.Tests
+﻿namespace Nut.Tests
 {
     /// <summary>
     /// Spanish numerals, per RAE. Three separate rules were wrong:
@@ -73,6 +73,25 @@ namespace Nut.Tests
         public void HundredsUseTheMasculineForm(long number, string expected)
         {
             Assert.That(number.ToText(Language.Spanish), Is.EqualTo(expected));
+        }
+
+        /// <summary>RAE: millón is a noun and links what it counts with "de"; mil is an
+        /// adjective and takes none.</summary>
+        [TestCase(1000000, "un millón de euros con cero céntimo de euro")]
+        [TestCase(2000000, "dos millones de euros con cero céntimo de euro")]
+        [TestCase(1000000000, "mil millones de euros con cero céntimo de euro")]
+        public void ScaleNounsLinkWithDe(decimal amount, string expected)
+        {
+            Assert.That(amount.ToText(Currency.EUR, Language.Spanish), Is.EqualTo(expected));
+        }
+
+        /// <summary>No "de" when mil ends the amount, or when the scale noun is not final.</summary>
+        [TestCase(1000, "mil euros con cero céntimo de euro")]
+        [TestCase(2000, "dos mil euros con cero céntimo de euro")]
+        [TestCase(1500000, "un millón quinientos mil euros con cero céntimo de euro")]
+        public void NoDeWhereItDoesNotBelong(decimal amount, string expected)
+        {
+            Assert.That(amount.ToText(Currency.EUR, Language.Spanish), Is.EqualTo(expected));
         }
 
         [Test]

--- a/src/Nut.Tests/behaviour-snapshot.tsv
+++ b/src/Nut.Tests/behaviour-snapshot.tsv
@@ -1437,9 +1437,9 @@ money	es	eur	22000	veintidós mil euros con cero céntimo de euro
 money	es	eur	41000	cuarenta y un mil euros con cero céntimo de euro
 money	es	eur	42000	cuarenta y dos mil euros con cero céntimo de euro
 money	es	eur	100000	cien mil euros con cero céntimo de euro
-money	es	eur	1000000	un millón euros con cero céntimo de euro
-money	es	eur	2000000	dos millones euros con cero céntimo de euro
-money	es	eur	1000000000	mil millones euros con cero céntimo de euro
+money	es	eur	1000000	un millón de euros con cero céntimo de euro
+money	es	eur	2000000	dos millones de euros con cero céntimo de euro
+money	es	eur	1000000000	mil millones de euros con cero céntimo de euro
 money	es	eur	123.45	ciento veintitrés euros con cuarenta y cinco céntimos de euro
 money	es	eur	-1	menos un euro con cero céntimo de euro
 money	es	eur	-2	menos dos euros con cero céntimo de euro
@@ -1476,9 +1476,9 @@ money	es	usd	22000	veintidós mil dólares con cero centavo
 money	es	usd	41000	cuarenta y un mil dólares con cero centavo
 money	es	usd	42000	cuarenta y dos mil dólares con cero centavo
 money	es	usd	100000	cien mil dólares con cero centavo
-money	es	usd	1000000	un millón dólares con cero centavo
-money	es	usd	2000000	dos millones dólares con cero centavo
-money	es	usd	1000000000	mil millones dólares con cero centavo
+money	es	usd	1000000	un millón de dólares con cero centavo
+money	es	usd	2000000	dos millones de dólares con cero centavo
+money	es	usd	1000000000	mil millones de dólares con cero centavo
 money	es	usd	123.45	ciento veintitrés dólares con cuarenta y cinco centavos
 money	es	usd	-1	menos un dólar con cero centavo
 money	es	usd	-2	menos dos dólares con cero centavo
@@ -1515,9 +1515,9 @@ money	es	rub	22000	veintidós mil rublos con cero kopek
 money	es	rub	41000	cuarenta y un mil rublos con cero kopek
 money	es	rub	42000	cuarenta y dos mil rublos con cero kopek
 money	es	rub	100000	cien mil rublos con cero kopek
-money	es	rub	1000000	un millón rublos con cero kopek
-money	es	rub	2000000	dos millones rublos con cero kopek
-money	es	rub	1000000000	mil millones rublos con cero kopek
+money	es	rub	1000000	un millón de rublos con cero kopek
+money	es	rub	2000000	dos millones de rublos con cero kopek
+money	es	rub	1000000000	mil millones de rublos con cero kopek
 money	es	rub	123.45	ciento veintitrés rublos con cuarenta y cinco kopeks
 money	es	rub	-1	menos un rublo con cero kopek
 money	es	rub	-2	menos dos rublos con cero kopek
@@ -1554,9 +1554,9 @@ money	es	try	22000	veintidós mil liras turco con cero kuruş
 money	es	try	41000	cuarenta y un mil liras turco con cero kuruş
 money	es	try	42000	cuarenta y dos mil liras turco con cero kuruş
 money	es	try	100000	cien mil liras turco con cero kuruş
-money	es	try	1000000	un millón liras turco con cero kuruş
-money	es	try	2000000	dos millones liras turco con cero kuruş
-money	es	try	1000000000	mil millones liras turco con cero kuruş
+money	es	try	1000000	un millón de liras turco con cero kuruş
+money	es	try	2000000	dos millones de liras turco con cero kuruş
+money	es	try	1000000000	mil millones de liras turco con cero kuruş
 money	es	try	123.45	ciento veintitrés liras turco con cuarenta y cinco kuruş
 money	es	try	-1	menos un lira turco con cero kuruş
 money	es	try	-2	menos dos liras turco con cero kuruş
@@ -1593,9 +1593,9 @@ money	es	uah	22000	veintidós mil grivnas ucraniana con cero kopek
 money	es	uah	41000	cuarenta y un mil grivnas ucraniana con cero kopek
 money	es	uah	42000	cuarenta y dos mil grivnas ucraniana con cero kopek
 money	es	uah	100000	cien mil grivnas ucraniana con cero kopek
-money	es	uah	1000000	un millón grivnas ucraniana con cero kopek
-money	es	uah	2000000	dos millones grivnas ucraniana con cero kopek
-money	es	uah	1000000000	mil millones grivnas ucraniana con cero kopek
+money	es	uah	1000000	un millón de grivnas ucraniana con cero kopek
+money	es	uah	2000000	dos millones de grivnas ucraniana con cero kopek
+money	es	uah	1000000000	mil millones de grivnas ucraniana con cero kopek
 money	es	uah	123.45	ciento veintitrés grivnas ucraniana con cuarenta y cinco kopeks
 money	es	uah	-1	menos un grivna ucraniana con cero kopek
 money	es	uah	-2	menos dos grivnas ucraniana con cero kopek
@@ -1671,9 +1671,9 @@ money	es	etb	22000	veintidós mil birr con cero centavo
 money	es	etb	41000	cuarenta y un mil birr con cero centavo
 money	es	etb	42000	cuarenta y dos mil birr con cero centavo
 money	es	etb	100000	cien mil birr con cero centavo
-money	es	etb	1000000	un millón birr con cero centavo
-money	es	etb	2000000	dos millones birr con cero centavo
-money	es	etb	1000000000	mil millones birr con cero centavo
+money	es	etb	1000000	un millón de birr con cero centavo
+money	es	etb	2000000	dos millones de birr con cero centavo
+money	es	etb	1000000000	mil millones de birr con cero centavo
 money	es	etb	123.45	ciento veintitrés birr con cuarenta y cinco centavos
 money	es	etb	-1	menos un birr con cero centavo
 money	es	etb	-2	menos dos birr con cero centavo
@@ -1710,9 +1710,9 @@ money	es	pln	22000	veintidós mil zloty con cero groszy
 money	es	pln	41000	cuarenta y un mil zloty con cero groszy
 money	es	pln	42000	cuarenta y dos mil zloty con cero groszy
 money	es	pln	100000	cien mil zloty con cero groszy
-money	es	pln	1000000	un millón zloty con cero groszy
-money	es	pln	2000000	dos millones zloty con cero groszy
-money	es	pln	1000000000	mil millones zloty con cero groszy
+money	es	pln	1000000	un millón de zloty con cero groszy
+money	es	pln	2000000	dos millones de zloty con cero groszy
+money	es	pln	1000000000	mil millones de zloty con cero groszy
 money	es	pln	123.45	ciento veintitrés zloty con cuarenta y cinco groszy
 money	es	pln	-1	menos un zloty con cero groszy
 money	es	pln	-2	menos dos zloty con cero groszy
@@ -1749,9 +1749,9 @@ money	es	byn	22000	veintidós mil rublos bielorrusos con cero kopek
 money	es	byn	41000	cuarenta y un mil rublos bielorrusos con cero kopek
 money	es	byn	42000	cuarenta y dos mil rublos bielorrusos con cero kopek
 money	es	byn	100000	cien mil rublos bielorrusos con cero kopek
-money	es	byn	1000000	un millón rublos bielorrusos con cero kopek
-money	es	byn	2000000	dos millones rublos bielorrusos con cero kopek
-money	es	byn	1000000000	mil millones rublos bielorrusos con cero kopek
+money	es	byn	1000000	un millón de rublos bielorrusos con cero kopek
+money	es	byn	2000000	dos millones de rublos bielorrusos con cero kopek
+money	es	byn	1000000000	mil millones de rublos bielorrusos con cero kopek
 money	es	byn	123.45	ciento veintitrés rublos bielorrusos con cuarenta y cinco kopeks
 money	es	byn	-1	menos un rublo bielorruso con cero kopek
 money	es	byn	-2	menos dos rublos bielorrusos con cero kopek
@@ -1788,9 +1788,9 @@ money	es	ars	22000	veintidós mil pesos con cero centavo
 money	es	ars	41000	cuarenta y un mil pesos con cero centavo
 money	es	ars	42000	cuarenta y dos mil pesos con cero centavo
 money	es	ars	100000	cien mil pesos con cero centavo
-money	es	ars	1000000	un millón pesos con cero centavo
-money	es	ars	2000000	dos millones pesos con cero centavo
-money	es	ars	1000000000	mil millones pesos con cero centavo
+money	es	ars	1000000	un millón de pesos con cero centavo
+money	es	ars	2000000	dos millones de pesos con cero centavo
+money	es	ars	1000000000	mil millones de pesos con cero centavo
 money	es	ars	123.45	ciento veintitrés pesos con cuarenta y cinco centavos
 money	es	ars	-1	menos un peso con cero centavo
 money	es	ars	-2	menos dos pesos con cero centavo

--- a/src/Nut/TextConverters/SpanishConverter.cs
+++ b/src/Nut/TextConverters/SpanishConverter.cs
@@ -116,6 +116,18 @@ namespace Nut.TextConverters
       return num;
     }
 
+    /// <summary>
+    /// RAE: millón and millardo are nouns, and what they count is linked to them with
+    /// "de" — "un millón de euros", never "un millón euros". mil is an adjective and takes
+    /// none, so "mil euros" stays as it is. The preposition only appears when the amount
+    /// ends on the scale noun; "un millón uno" is followed directly by the currency.
+    /// </summary>
+    protected override string GetCurrencyText(long num, CurrencyModel currency)
+    {
+      var name = base.GetCurrencyText(num, currency);
+      return num >= 1000000 && num % 1000000 == 0 ? "de " + name : name;
+    }
+
     protected override string GetUnitSeparator(CurrencyModel currency)
     {
       return " con ";


### PR DESCRIPTION
Follow-up to #43. **Changes produced text**, so 4.0.0.

[RAE](https://www.rae.es/dpd/n%C3%BAmeros): `millón`, `millardo` and `billón` are **nouns**, and what they quantify is introduced by `de`. Constructions like `millón habitantes` are explicitly listed as not admissible.

| Amount | Before | After |
|---|---|---|
| `1000000 EUR` | un millón euros | **un millón de euros** |
| `2000000 EUR` | dos millones euros | **dos millones de euros** |
| `1000000000 EUR` | mil millones euros | **mil millones de euros** |

## Where it does not belong

`mil` is an adjective, not a noun, so it takes no preposition:

```
1000 EUR     mil euros                           (unchanged)
1500000 EUR  un millón quinientos mil euros      (unchanged)
```

The second case matters: what follows `millón` there is another numeral, not the currency, so the preposition would be wrong. The rule is applied only when the amount **ends** on the scale noun.

## Verification

- **27 of 5520 conversions change, all Spanish.**
- 467 tests.

## Noticed, not fixed

`1000001 EUR` reads as `un millón un euros` — the currency is pluralised from the whole amount rather than from the part next to it, so a number ending in "one" still takes a plural noun. That is a different rule and probably affects more than Spanish; I left it alone rather than widen this PR.