### PR TITLE
feat: British English says "and" before the final group

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -103,6 +103,10 @@ assert on that text, review the tables below before taking this release.
   separates them only from a million upwards: `ein hundert` → `einhundert`,
   `einundvierzig tausend` → `einundvierzigtausend`. Standing alone the numeral is `eins`;
   `ein` is kept before a noun.
+- **British English now says "and"**: `en-GB` was resolving to the same converter as
+  `en-US`, so it produced American wording. `101` reads as `one hundred and one` in
+  `en-GB` and `one hundred one` in `en-US`. On a cheque the written amount is the one the
+  bank honours, so the two conventions are kept apart.
 - **English** hyphenates compounds: `twenty one` → `twenty-one`. Only the tens-and-units
   pair, so `121` is `one hundred twenty-one`.
 - **French** hyphenates compounds below a hundred (`quarante-deux`), agrees multiplied

--- a/README.md
+++ b/README.md
@@ -21,6 +21,9 @@ Money To Text Converter
 half away from zero — the same result `decimal.ToString("C")` gives. Set
 `Options.SubUnitTruncated` to cut the extra digits instead.
 
+**English variants:** `en-US` and `en` give American wording (`one hundred one`); `en-GB`
+gives British wording (`one hundred and one`).
+
 **Target Framework:** .NET Standard 2.0 — runs on .NET Framework 4.6.1+, .NET Core 2.0+ and .NET 5 and later.
 
 ---

--- a/src/Nut.Tests/BehaviourSnapshot.cs
+++ b/src/Nut.Tests/BehaviourSnapshot.cs
@@ -27,7 +27,7 @@ namespace Nut.Tests
             Language.English, Language.French, Language.German, Language.Spanish,
             Language.Portuguese, Language.Turkish, Language.Russian, Language.Ukrainian,
             Language.Belarusian, Language.Bulgarian, Language.Polish, Language.Amharic,
-            Language.Uzbek,
+            Language.Uzbek, Culture.EnglishGB,
         };
 
         private static readonly string[] Currencies =

--- a/src/Nut.Tests/BritishEnglish.cs
+++ b/src/Nut.Tests/BritishEnglish.cs
@@ -1,0 +1,63 @@
+namespace Nut.Tests
+{
+    /// <summary>
+    /// British usage puts "and" before the final group when it is under a hundred;
+    /// American usage drops it. Both cultures were resolving to the same converter, so
+    /// asking for en-GB produced American wording.
+    ///
+    /// This matters more than style here: on a cheque the written amount is the one the
+    /// bank honours, so the two conventions are kept apart rather than merged.
+    /// </summary>
+    [TestFixture]
+    public class BritishEnglish
+    {
+        [TestCase(101, "one hundred and one")]
+        [TestCase(110, "one hundred and ten")]
+        [TestCase(121, "one hundred and twenty-one")]
+        [TestCase(999, "nine hundred and ninety-nine")]
+        [TestCase(1001, "one thousand and one")]
+        [TestCase(5026, "five thousand and twenty-six")]
+        [TestCase(1101, "one thousand one hundred and one")]
+        [TestCase(1000001, "one million and one")]
+        public void AndBeforeTheFinalGroup(long number, string expected)
+        {
+            Assert.That(number.ToText(Culture.EnglishGB), Is.EqualTo(expected));
+        }
+
+        /// <summary>No "and" when the number ends on a round hundred or higher.</summary>
+        [TestCase(100, "one hundred")]
+        [TestCase(1000, "one thousand")]
+        [TestCase(1100, "one thousand one hundred")]
+        [TestCase(100000, "one hundred thousand")]
+        [TestCase(21, "twenty-one")]
+        public void NoAndWhereItDoesNotBelong(long number, string expected)
+        {
+            Assert.That(number.ToText(Culture.EnglishGB), Is.EqualTo(expected));
+        }
+
+        /// <summary>American wording is unchanged.</summary>
+        [TestCase(101, "one hundred one")]
+        [TestCase(5026, "five thousand twenty-six")]
+        public void AmericanStaysAsItWas(long number, string expected)
+        {
+            Assert.That(number.ToText(Culture.EnglishUS), Is.EqualTo(expected));
+            Assert.That(number.ToText(Language.English), Is.EqualTo(expected));
+        }
+
+        [Test]
+        public void AmountsFollowTheSameRule()
+        {
+            Assert.That(101.25m.ToText(Currency.GBP, Culture.EnglishGB),
+                Is.EqualTo("one hundred and one pounds sterling twenty-five pence"));
+            Assert.That(101.25m.ToText(Currency.USD, Culture.EnglishUS),
+                Is.EqualTo("one hundred one dollars twenty-five cents"));
+        }
+
+        [Test]
+        public void CaseStillDoesNotMatter()
+        {
+            Assert.That(101.ToText("EN-GB"), Is.EqualTo("one hundred and one"));
+            Assert.That(101.ToText("en-gb"), Is.EqualTo("one hundred and one"));
+        }
+    }
+}

--- a/src/Nut.Tests/LanguageResolution.cs
+++ b/src/Nut.Tests/LanguageResolution.cs
@@ -1,4 +1,4 @@
-namespace Nut.Tests
+﻿namespace Nut.Tests
 {
     /// <summary>
     /// Which language string resolves to which converter. The int overloads used to
@@ -11,7 +11,7 @@ namespace Nut.Tests
     public class LanguageResolution
     {
         [TestCase(Culture.EnglishUS, "one hundred one")]
-        [TestCase(Culture.EnglishGB, "one hundred one")]
+        [TestCase(Culture.EnglishGB, "one hundred and one")] // British "and"
         [TestCase(Culture.French, "cent un")]
         [TestCase(Culture.GermanDE, "einhunderteins")]
         [TestCase(Culture.Spanish, "ciento uno")]

--- a/src/Nut.Tests/behaviour-snapshot.tsv
+++ b/src/Nut.Tests/behaviour-snapshot.tsv
@@ -6992,3 +6992,541 @@ money	uz	gbp	-1000	minus ming funt sterling nol pens
 money	uz	gbp	1.999	ikki funt sterling nol pens
 money	uz	gbp	123.456	yuz yigirma uch funt sterling qirq olti pens
 money	uz	gbp	1.005	bir funt sterling bir pens
+plain	en-GB	0	zero
+plain	en-GB	1	one
+plain	en-GB	2	two
+plain	en-GB	3	three
+plain	en-GB	5	five
+plain	en-GB	11	eleven
+plain	en-GB	15	fifteen
+plain	en-GB	20	twenty
+plain	en-GB	21	twenty-one
+plain	en-GB	22	twenty-two
+plain	en-GB	42	forty-two
+plain	en-GB	100	one hundred
+plain	en-GB	101	one hundred and one
+plain	en-GB	121	one hundred and twenty-one
+plain	en-GB	200	two hundred
+plain	en-GB	999	nine hundred and ninety-nine
+plain	en-GB	1000	one thousand
+plain	en-GB	1001	one thousand and one
+plain	en-GB	2000	two thousand
+plain	en-GB	5000	five thousand
+plain	en-GB	21000	twenty-one thousand
+plain	en-GB	41000	forty-one thousand
+plain	en-GB	100000	one hundred thousand
+plain	en-GB	1000000	one million
+plain	en-GB	2000000	two million
+plain	en-GB	999999999	nine hundred and ninety-nine million nine hundred and ninety-nine thousand nine hundred and ninety-nine
+plain	en-GB	-1	minus one
+plain	en-GB	-2	minus two
+plain	en-GB	-41	minus forty-one
+plain	en-GB	-1000	minus one thousand
+plain	en-GB	-1000000	minus one million
+money	en-GB	eur	0	zero euro zero eurocent
+money	en-GB	eur	0.01	zero euro one eurocent
+money	en-GB	eur	0.02	zero euro two eurocents
+money	en-GB	eur	1	one euro zero eurocent
+money	en-GB	eur	1.01	one euro one eurocent
+money	en-GB	eur	1.02	one euro two eurocents
+money	en-GB	eur	2	two euros zero eurocent
+money	en-GB	eur	2.02	two euros two eurocents
+money	en-GB	eur	3	three euros zero eurocent
+money	en-GB	eur	5	five euros zero eurocent
+money	en-GB	eur	11	eleven euros zero eurocent
+money	en-GB	eur	21	twenty-one euros zero eurocent
+money	en-GB	eur	22	twenty-two euros zero eurocent
+money	en-GB	eur	42	forty-two euros zero eurocent
+money	en-GB	eur	100	one hundred euros zero eurocent
+money	en-GB	eur	101	one hundred and one euros zero eurocent
+money	en-GB	eur	121	one hundred and twenty-one euros zero eurocent
+money	en-GB	eur	999	nine hundred and ninety-nine euros zero eurocent
+money	en-GB	eur	1000	one thousand euros zero eurocent
+money	en-GB	eur	1001	one thousand and one euros zero eurocent
+money	en-GB	eur	2000	two thousand euros zero eurocent
+money	en-GB	eur	2001	two thousand and one euros zero eurocent
+money	en-GB	eur	5000	five thousand euros zero eurocent
+money	en-GB	eur	21000	twenty-one thousand euros zero eurocent
+money	en-GB	eur	22000	twenty-two thousand euros zero eurocent
+money	en-GB	eur	41000	forty-one thousand euros zero eurocent
+money	en-GB	eur	42000	forty-two thousand euros zero eurocent
+money	en-GB	eur	100000	one hundred thousand euros zero eurocent
+money	en-GB	eur	1000000	one million euros zero eurocent
+money	en-GB	eur	2000000	two million euros zero eurocent
+money	en-GB	eur	1000000000	one billion euros zero eurocent
+money	en-GB	eur	123.45	one hundred and twenty-three euros forty-five eurocents
+money	en-GB	eur	-1	minus one euro zero eurocent
+money	en-GB	eur	-2	minus two euros zero eurocent
+money	en-GB	eur	-41.5	minus forty-one euros fifty eurocents
+money	en-GB	eur	-1000	minus one thousand euros zero eurocent
+money	en-GB	eur	1.999	two euros zero eurocent
+money	en-GB	eur	123.456	one hundred and twenty-three euros forty-six eurocents
+money	en-GB	eur	1.005	one euro one eurocent
+money	en-GB	usd	0	zero dollar zero cent
+money	en-GB	usd	0.01	zero dollar one cent
+money	en-GB	usd	0.02	zero dollar two cents
+money	en-GB	usd	1	one dollar zero cent
+money	en-GB	usd	1.01	one dollar one cent
+money	en-GB	usd	1.02	one dollar two cents
+money	en-GB	usd	2	two dollars zero cent
+money	en-GB	usd	2.02	two dollars two cents
+money	en-GB	usd	3	three dollars zero cent
+money	en-GB	usd	5	five dollars zero cent
+money	en-GB	usd	11	eleven dollars zero cent
+money	en-GB	usd	21	twenty-one dollars zero cent
+money	en-GB	usd	22	twenty-two dollars zero cent
+money	en-GB	usd	42	forty-two dollars zero cent
+money	en-GB	usd	100	one hundred dollars zero cent
+money	en-GB	usd	101	one hundred and one dollars zero cent
+money	en-GB	usd	121	one hundred and twenty-one dollars zero cent
+money	en-GB	usd	999	nine hundred and ninety-nine dollars zero cent
+money	en-GB	usd	1000	one thousand dollars zero cent
+money	en-GB	usd	1001	one thousand and one dollars zero cent
+money	en-GB	usd	2000	two thousand dollars zero cent
+money	en-GB	usd	2001	two thousand and one dollars zero cent
+money	en-GB	usd	5000	five thousand dollars zero cent
+money	en-GB	usd	21000	twenty-one thousand dollars zero cent
+money	en-GB	usd	22000	twenty-two thousand dollars zero cent
+money	en-GB	usd	41000	forty-one thousand dollars zero cent
+money	en-GB	usd	42000	forty-two thousand dollars zero cent
+money	en-GB	usd	100000	one hundred thousand dollars zero cent
+money	en-GB	usd	1000000	one million dollars zero cent
+money	en-GB	usd	2000000	two million dollars zero cent
+money	en-GB	usd	1000000000	one billion dollars zero cent
+money	en-GB	usd	123.45	one hundred and twenty-three dollars forty-five cents
+money	en-GB	usd	-1	minus one dollar zero cent
+money	en-GB	usd	-2	minus two dollars zero cent
+money	en-GB	usd	-41.5	minus forty-one dollars fifty cents
+money	en-GB	usd	-1000	minus one thousand dollars zero cent
+money	en-GB	usd	1.999	two dollars zero cent
+money	en-GB	usd	123.456	one hundred and twenty-three dollars forty-six cents
+money	en-GB	usd	1.005	one dollar one cent
+money	en-GB	rub	0	zero ruble zero kopek
+money	en-GB	rub	0.01	zero ruble one kopek
+money	en-GB	rub	0.02	zero ruble two kopeks
+money	en-GB	rub	1	one ruble zero kopek
+money	en-GB	rub	1.01	one ruble one kopek
+money	en-GB	rub	1.02	one ruble two kopeks
+money	en-GB	rub	2	two rubles zero kopek
+money	en-GB	rub	2.02	two rubles two kopeks
+money	en-GB	rub	3	three rubles zero kopek
+money	en-GB	rub	5	five rubles zero kopek
+money	en-GB	rub	11	eleven rubles zero kopek
+money	en-GB	rub	21	twenty-one rubles zero kopek
+money	en-GB	rub	22	twenty-two rubles zero kopek
+money	en-GB	rub	42	forty-two rubles zero kopek
+money	en-GB	rub	100	one hundred rubles zero kopek
+money	en-GB	rub	101	one hundred and one rubles zero kopek
+money	en-GB	rub	121	one hundred and twenty-one rubles zero kopek
+money	en-GB	rub	999	nine hundred and ninety-nine rubles zero kopek
+money	en-GB	rub	1000	one thousand rubles zero kopek
+money	en-GB	rub	1001	one thousand and one rubles zero kopek
+money	en-GB	rub	2000	two thousand rubles zero kopek
+money	en-GB	rub	2001	two thousand and one rubles zero kopek
+money	en-GB	rub	5000	five thousand rubles zero kopek
+money	en-GB	rub	21000	twenty-one thousand rubles zero kopek
+money	en-GB	rub	22000	twenty-two thousand rubles zero kopek
+money	en-GB	rub	41000	forty-one thousand rubles zero kopek
+money	en-GB	rub	42000	forty-two thousand rubles zero kopek
+money	en-GB	rub	100000	one hundred thousand rubles zero kopek
+money	en-GB	rub	1000000	one million rubles zero kopek
+money	en-GB	rub	2000000	two million rubles zero kopek
+money	en-GB	rub	1000000000	one billion rubles zero kopek
+money	en-GB	rub	123.45	one hundred and twenty-three rubles forty-five kopeks
+money	en-GB	rub	-1	minus one ruble zero kopek
+money	en-GB	rub	-2	minus two rubles zero kopek
+money	en-GB	rub	-41.5	minus forty-one rubles fifty kopeks
+money	en-GB	rub	-1000	minus one thousand rubles zero kopek
+money	en-GB	rub	1.999	two rubles zero kopek
+money	en-GB	rub	123.456	one hundred and twenty-three rubles forty-six kopeks
+money	en-GB	rub	1.005	one ruble one kopek
+money	en-GB	try	0	zero turkish lira zero kurus
+money	en-GB	try	0.01	zero turkish lira one kurus
+money	en-GB	try	0.02	zero turkish lira two kurus
+money	en-GB	try	1	one turkish lira zero kurus
+money	en-GB	try	1.01	one turkish lira one kurus
+money	en-GB	try	1.02	one turkish lira two kurus
+money	en-GB	try	2	two turkish lira zero kurus
+money	en-GB	try	2.02	two turkish lira two kurus
+money	en-GB	try	3	three turkish lira zero kurus
+money	en-GB	try	5	five turkish lira zero kurus
+money	en-GB	try	11	eleven turkish lira zero kurus
+money	en-GB	try	21	twenty-one turkish lira zero kurus
+money	en-GB	try	22	twenty-two turkish lira zero kurus
+money	en-GB	try	42	forty-two turkish lira zero kurus
+money	en-GB	try	100	one hundred turkish lira zero kurus
+money	en-GB	try	101	one hundred and one turkish lira zero kurus
+money	en-GB	try	121	one hundred and twenty-one turkish lira zero kurus
+money	en-GB	try	999	nine hundred and ninety-nine turkish lira zero kurus
+money	en-GB	try	1000	one thousand turkish lira zero kurus
+money	en-GB	try	1001	one thousand and one turkish lira zero kurus
+money	en-GB	try	2000	two thousand turkish lira zero kurus
+money	en-GB	try	2001	two thousand and one turkish lira zero kurus
+money	en-GB	try	5000	five thousand turkish lira zero kurus
+money	en-GB	try	21000	twenty-one thousand turkish lira zero kurus
+money	en-GB	try	22000	twenty-two thousand turkish lira zero kurus
+money	en-GB	try	41000	forty-one thousand turkish lira zero kurus
+money	en-GB	try	42000	forty-two thousand turkish lira zero kurus
+money	en-GB	try	100000	one hundred thousand turkish lira zero kurus
+money	en-GB	try	1000000	one million turkish lira zero kurus
+money	en-GB	try	2000000	two million turkish lira zero kurus
+money	en-GB	try	1000000000	one billion turkish lira zero kurus
+money	en-GB	try	123.45	one hundred and twenty-three turkish lira forty-five kurus
+money	en-GB	try	-1	minus one turkish lira zero kurus
+money	en-GB	try	-2	minus two turkish lira zero kurus
+money	en-GB	try	-41.5	minus forty-one turkish lira fifty kurus
+money	en-GB	try	-1000	minus one thousand turkish lira zero kurus
+money	en-GB	try	1.999	two turkish lira zero kurus
+money	en-GB	try	123.456	one hundred and twenty-three turkish lira forty-six kurus
+money	en-GB	try	1.005	one turkish lira one kurus
+money	en-GB	uah	0	zero ukrainian hryvnia zero kopiyka
+money	en-GB	uah	0.01	zero ukrainian hryvnia one kopiyka
+money	en-GB	uah	0.02	zero ukrainian hryvnia two kopiyky
+money	en-GB	uah	1	one ukrainian hryvnia zero kopiyka
+money	en-GB	uah	1.01	one ukrainian hryvnia one kopiyka
+money	en-GB	uah	1.02	one ukrainian hryvnia two kopiyky
+money	en-GB	uah	2	two ukrainian hryvnia zero kopiyka
+money	en-GB	uah	2.02	two ukrainian hryvnia two kopiyky
+money	en-GB	uah	3	three ukrainian hryvnia zero kopiyka
+money	en-GB	uah	5	five ukrainian hryvnia zero kopiyka
+money	en-GB	uah	11	eleven ukrainian hryvnia zero kopiyka
+money	en-GB	uah	21	twenty-one ukrainian hryvnia zero kopiyka
+money	en-GB	uah	22	twenty-two ukrainian hryvnia zero kopiyka
+money	en-GB	uah	42	forty-two ukrainian hryvnia zero kopiyka
+money	en-GB	uah	100	one hundred ukrainian hryvnia zero kopiyka
+money	en-GB	uah	101	one hundred and one ukrainian hryvnia zero kopiyka
+money	en-GB	uah	121	one hundred and twenty-one ukrainian hryvnia zero kopiyka
+money	en-GB	uah	999	nine hundred and ninety-nine ukrainian hryvnia zero kopiyka
+money	en-GB	uah	1000	one thousand ukrainian hryvnia zero kopiyka
+money	en-GB	uah	1001	one thousand and one ukrainian hryvnia zero kopiyka
+money	en-GB	uah	2000	two thousand ukrainian hryvnia zero kopiyka
+money	en-GB	uah	2001	two thousand and one ukrainian hryvnia zero kopiyka
+money	en-GB	uah	5000	five thousand ukrainian hryvnia zero kopiyka
+money	en-GB	uah	21000	twenty-one thousand ukrainian hryvnia zero kopiyka
+money	en-GB	uah	22000	twenty-two thousand ukrainian hryvnia zero kopiyka
+money	en-GB	uah	41000	forty-one thousand ukrainian hryvnia zero kopiyka
+money	en-GB	uah	42000	forty-two thousand ukrainian hryvnia zero kopiyka
+money	en-GB	uah	100000	one hundred thousand ukrainian hryvnia zero kopiyka
+money	en-GB	uah	1000000	one million ukrainian hryvnia zero kopiyka
+money	en-GB	uah	2000000	two million ukrainian hryvnia zero kopiyka
+money	en-GB	uah	1000000000	one billion ukrainian hryvnia zero kopiyka
+money	en-GB	uah	123.45	one hundred and twenty-three ukrainian hryvnia forty-five kopiyky
+money	en-GB	uah	-1	minus one ukrainian hryvnia zero kopiyka
+money	en-GB	uah	-2	minus two ukrainian hryvnia zero kopiyka
+money	en-GB	uah	-41.5	minus forty-one ukrainian hryvnia fifty kopiyky
+money	en-GB	uah	-1000	minus one thousand ukrainian hryvnia zero kopiyka
+money	en-GB	uah	1.999	two ukrainian hryvnia zero kopiyka
+money	en-GB	uah	123.456	one hundred and twenty-three ukrainian hryvnia forty-six kopiyky
+money	en-GB	uah	1.005	one ukrainian hryvnia one kopiyka
+money	en-GB	bgn	0	zero Bulgarian lev zero stotinka
+money	en-GB	bgn	0.01	zero Bulgarian lev one stotinka
+money	en-GB	bgn	0.02	zero Bulgarian lev two stotinki
+money	en-GB	bgn	1	one Bulgarian lev zero stotinka
+money	en-GB	bgn	1.01	one Bulgarian lev one stotinka
+money	en-GB	bgn	1.02	one Bulgarian lev two stotinki
+money	en-GB	bgn	2	two Bulgarian leva zero stotinka
+money	en-GB	bgn	2.02	two Bulgarian leva two stotinki
+money	en-GB	bgn	3	three Bulgarian leva zero stotinka
+money	en-GB	bgn	5	five Bulgarian leva zero stotinka
+money	en-GB	bgn	11	eleven Bulgarian leva zero stotinka
+money	en-GB	bgn	21	twenty-one Bulgarian leva zero stotinka
+money	en-GB	bgn	22	twenty-two Bulgarian leva zero stotinka
+money	en-GB	bgn	42	forty-two Bulgarian leva zero stotinka
+money	en-GB	bgn	100	one hundred Bulgarian leva zero stotinka
+money	en-GB	bgn	101	one hundred and one Bulgarian leva zero stotinka
+money	en-GB	bgn	121	one hundred and twenty-one Bulgarian leva zero stotinka
+money	en-GB	bgn	999	nine hundred and ninety-nine Bulgarian leva zero stotinka
+money	en-GB	bgn	1000	one thousand Bulgarian leva zero stotinka
+money	en-GB	bgn	1001	one thousand and one Bulgarian leva zero stotinka
+money	en-GB	bgn	2000	two thousand Bulgarian leva zero stotinka
+money	en-GB	bgn	2001	two thousand and one Bulgarian leva zero stotinka
+money	en-GB	bgn	5000	five thousand Bulgarian leva zero stotinka
+money	en-GB	bgn	21000	twenty-one thousand Bulgarian leva zero stotinka
+money	en-GB	bgn	22000	twenty-two thousand Bulgarian leva zero stotinka
+money	en-GB	bgn	41000	forty-one thousand Bulgarian leva zero stotinka
+money	en-GB	bgn	42000	forty-two thousand Bulgarian leva zero stotinka
+money	en-GB	bgn	100000	one hundred thousand Bulgarian leva zero stotinka
+money	en-GB	bgn	1000000	one million Bulgarian leva zero stotinka
+money	en-GB	bgn	2000000	two million Bulgarian leva zero stotinka
+money	en-GB	bgn	1000000000	one billion Bulgarian leva zero stotinka
+money	en-GB	bgn	123.45	one hundred and twenty-three Bulgarian leva forty-five stotinki
+money	en-GB	bgn	-1	minus one Bulgarian lev zero stotinka
+money	en-GB	bgn	-2	minus two Bulgarian leva zero stotinka
+money	en-GB	bgn	-41.5	minus forty-one Bulgarian leva fifty stotinki
+money	en-GB	bgn	-1000	minus one thousand Bulgarian leva zero stotinka
+money	en-GB	bgn	1.999	two Bulgarian leva zero stotinka
+money	en-GB	bgn	123.456	one hundred and twenty-three Bulgarian leva forty-six stotinki
+money	en-GB	bgn	1.005	one Bulgarian lev one stotinka
+money	en-GB	etb	0	zero birr zero cent
+money	en-GB	etb	0.01	zero birr one cent
+money	en-GB	etb	0.02	zero birr two cents
+money	en-GB	etb	1	one birr zero cent
+money	en-GB	etb	1.01	one birr one cent
+money	en-GB	etb	1.02	one birr two cents
+money	en-GB	etb	2	two birr zero cent
+money	en-GB	etb	2.02	two birr two cents
+money	en-GB	etb	3	three birr zero cent
+money	en-GB	etb	5	five birr zero cent
+money	en-GB	etb	11	eleven birr zero cent
+money	en-GB	etb	21	twenty-one birr zero cent
+money	en-GB	etb	22	twenty-two birr zero cent
+money	en-GB	etb	42	forty-two birr zero cent
+money	en-GB	etb	100	one hundred birr zero cent
+money	en-GB	etb	101	one hundred and one birr zero cent
+money	en-GB	etb	121	one hundred and twenty-one birr zero cent
+money	en-GB	etb	999	nine hundred and ninety-nine birr zero cent
+money	en-GB	etb	1000	one thousand birr zero cent
+money	en-GB	etb	1001	one thousand and one birr zero cent
+money	en-GB	etb	2000	two thousand birr zero cent
+money	en-GB	etb	2001	two thousand and one birr zero cent
+money	en-GB	etb	5000	five thousand birr zero cent
+money	en-GB	etb	21000	twenty-one thousand birr zero cent
+money	en-GB	etb	22000	twenty-two thousand birr zero cent
+money	en-GB	etb	41000	forty-one thousand birr zero cent
+money	en-GB	etb	42000	forty-two thousand birr zero cent
+money	en-GB	etb	100000	one hundred thousand birr zero cent
+money	en-GB	etb	1000000	one million birr zero cent
+money	en-GB	etb	2000000	two million birr zero cent
+money	en-GB	etb	1000000000	one billion birr zero cent
+money	en-GB	etb	123.45	one hundred and twenty-three birr forty-five cents
+money	en-GB	etb	-1	minus one birr zero cent
+money	en-GB	etb	-2	minus two birr zero cent
+money	en-GB	etb	-41.5	minus forty-one birr fifty cents
+money	en-GB	etb	-1000	minus one thousand birr zero cent
+money	en-GB	etb	1.999	two birr zero cent
+money	en-GB	etb	123.456	one hundred and twenty-three birr forty-six cents
+money	en-GB	etb	1.005	one birr one cent
+money	en-GB	pln	0	zero zloty zero grosz
+money	en-GB	pln	0.01	zero zloty one grosz
+money	en-GB	pln	0.02	zero zloty two grosze
+money	en-GB	pln	1	one zloty zero grosz
+money	en-GB	pln	1.01	one zloty one grosz
+money	en-GB	pln	1.02	one zloty two grosze
+money	en-GB	pln	2	two zloty zero grosz
+money	en-GB	pln	2.02	two zloty two grosze
+money	en-GB	pln	3	three zloty zero grosz
+money	en-GB	pln	5	five zloty zero grosz
+money	en-GB	pln	11	eleven zloty zero grosz
+money	en-GB	pln	21	twenty-one zloty zero grosz
+money	en-GB	pln	22	twenty-two zloty zero grosz
+money	en-GB	pln	42	forty-two zloty zero grosz
+money	en-GB	pln	100	one hundred zloty zero grosz
+money	en-GB	pln	101	one hundred and one zloty zero grosz
+money	en-GB	pln	121	one hundred and twenty-one zloty zero grosz
+money	en-GB	pln	999	nine hundred and ninety-nine zloty zero grosz
+money	en-GB	pln	1000	one thousand zloty zero grosz
+money	en-GB	pln	1001	one thousand and one zloty zero grosz
+money	en-GB	pln	2000	two thousand zloty zero grosz
+money	en-GB	pln	2001	two thousand and one zloty zero grosz
+money	en-GB	pln	5000	five thousand zloty zero grosz
+money	en-GB	pln	21000	twenty-one thousand zloty zero grosz
+money	en-GB	pln	22000	twenty-two thousand zloty zero grosz
+money	en-GB	pln	41000	forty-one thousand zloty zero grosz
+money	en-GB	pln	42000	forty-two thousand zloty zero grosz
+money	en-GB	pln	100000	one hundred thousand zloty zero grosz
+money	en-GB	pln	1000000	one million zloty zero grosz
+money	en-GB	pln	2000000	two million zloty zero grosz
+money	en-GB	pln	1000000000	one billion zloty zero grosz
+money	en-GB	pln	123.45	one hundred and twenty-three zloty forty-five grosze
+money	en-GB	pln	-1	minus one zloty zero grosz
+money	en-GB	pln	-2	minus two zloty zero grosz
+money	en-GB	pln	-41.5	minus forty-one zloty fifty grosze
+money	en-GB	pln	-1000	minus one thousand zloty zero grosz
+money	en-GB	pln	1.999	two zloty zero grosz
+money	en-GB	pln	123.456	one hundred and twenty-three zloty forty-six grosze
+money	en-GB	pln	1.005	one zloty one grosz
+money	en-GB	byn	0	zero Belarusian ruble zero kopek
+money	en-GB	byn	0.01	zero Belarusian ruble one kopek
+money	en-GB	byn	0.02	zero Belarusian ruble two kopeks
+money	en-GB	byn	1	one Belarusian ruble zero kopek
+money	en-GB	byn	1.01	one Belarusian ruble one kopek
+money	en-GB	byn	1.02	one Belarusian ruble two kopeks
+money	en-GB	byn	2	two Belarusian rubles zero kopek
+money	en-GB	byn	2.02	two Belarusian rubles two kopeks
+money	en-GB	byn	3	three Belarusian rubles zero kopek
+money	en-GB	byn	5	five Belarusian rubles zero kopek
+money	en-GB	byn	11	eleven Belarusian rubles zero kopek
+money	en-GB	byn	21	twenty-one Belarusian rubles zero kopek
+money	en-GB	byn	22	twenty-two Belarusian rubles zero kopek
+money	en-GB	byn	42	forty-two Belarusian rubles zero kopek
+money	en-GB	byn	100	one hundred Belarusian rubles zero kopek
+money	en-GB	byn	101	one hundred and one Belarusian rubles zero kopek
+money	en-GB	byn	121	one hundred and twenty-one Belarusian rubles zero kopek
+money	en-GB	byn	999	nine hundred and ninety-nine Belarusian rubles zero kopek
+money	en-GB	byn	1000	one thousand Belarusian rubles zero kopek
+money	en-GB	byn	1001	one thousand and one Belarusian rubles zero kopek
+money	en-GB	byn	2000	two thousand Belarusian rubles zero kopek
+money	en-GB	byn	2001	two thousand and one Belarusian rubles zero kopek
+money	en-GB	byn	5000	five thousand Belarusian rubles zero kopek
+money	en-GB	byn	21000	twenty-one thousand Belarusian rubles zero kopek
+money	en-GB	byn	22000	twenty-two thousand Belarusian rubles zero kopek
+money	en-GB	byn	41000	forty-one thousand Belarusian rubles zero kopek
+money	en-GB	byn	42000	forty-two thousand Belarusian rubles zero kopek
+money	en-GB	byn	100000	one hundred thousand Belarusian rubles zero kopek
+money	en-GB	byn	1000000	one million Belarusian rubles zero kopek
+money	en-GB	byn	2000000	two million Belarusian rubles zero kopek
+money	en-GB	byn	1000000000	one billion Belarusian rubles zero kopek
+money	en-GB	byn	123.45	one hundred and twenty-three Belarusian rubles forty-five kopeks
+money	en-GB	byn	-1	minus one Belarusian ruble zero kopek
+money	en-GB	byn	-2	minus two Belarusian rubles zero kopek
+money	en-GB	byn	-41.5	minus forty-one Belarusian rubles fifty kopeks
+money	en-GB	byn	-1000	minus one thousand Belarusian rubles zero kopek
+money	en-GB	byn	1.999	two Belarusian rubles zero kopek
+money	en-GB	byn	123.456	one hundred and twenty-three Belarusian rubles forty-six kopeks
+money	en-GB	byn	1.005	one Belarusian ruble one kopek
+money	en-GB	ars	0	zero Argentine peso zero centavo
+money	en-GB	ars	0.01	zero Argentine peso one centavo
+money	en-GB	ars	0.02	zero Argentine peso two centavos
+money	en-GB	ars	1	one Argentine peso zero centavo
+money	en-GB	ars	1.01	one Argentine peso one centavo
+money	en-GB	ars	1.02	one Argentine peso two centavos
+money	en-GB	ars	2	two Argentine pesos zero centavo
+money	en-GB	ars	2.02	two Argentine pesos two centavos
+money	en-GB	ars	3	three Argentine pesos zero centavo
+money	en-GB	ars	5	five Argentine pesos zero centavo
+money	en-GB	ars	11	eleven Argentine pesos zero centavo
+money	en-GB	ars	21	twenty-one Argentine pesos zero centavo
+money	en-GB	ars	22	twenty-two Argentine pesos zero centavo
+money	en-GB	ars	42	forty-two Argentine pesos zero centavo
+money	en-GB	ars	100	one hundred Argentine pesos zero centavo
+money	en-GB	ars	101	one hundred and one Argentine pesos zero centavo
+money	en-GB	ars	121	one hundred and twenty-one Argentine pesos zero centavo
+money	en-GB	ars	999	nine hundred and ninety-nine Argentine pesos zero centavo
+money	en-GB	ars	1000	one thousand Argentine pesos zero centavo
+money	en-GB	ars	1001	one thousand and one Argentine pesos zero centavo
+money	en-GB	ars	2000	two thousand Argentine pesos zero centavo
+money	en-GB	ars	2001	two thousand and one Argentine pesos zero centavo
+money	en-GB	ars	5000	five thousand Argentine pesos zero centavo
+money	en-GB	ars	21000	twenty-one thousand Argentine pesos zero centavo
+money	en-GB	ars	22000	twenty-two thousand Argentine pesos zero centavo
+money	en-GB	ars	41000	forty-one thousand Argentine pesos zero centavo
+money	en-GB	ars	42000	forty-two thousand Argentine pesos zero centavo
+money	en-GB	ars	100000	one hundred thousand Argentine pesos zero centavo
+money	en-GB	ars	1000000	one million Argentine pesos zero centavo
+money	en-GB	ars	2000000	two million Argentine pesos zero centavo
+money	en-GB	ars	1000000000	one billion Argentine pesos zero centavo
+money	en-GB	ars	123.45	one hundred and twenty-three Argentine pesos forty-five centavos
+money	en-GB	ars	-1	minus one Argentine peso zero centavo
+money	en-GB	ars	-2	minus two Argentine pesos zero centavo
+money	en-GB	ars	-41.5	minus forty-one Argentine pesos fifty centavos
+money	en-GB	ars	-1000	minus one thousand Argentine pesos zero centavo
+money	en-GB	ars	1.999	two Argentine pesos zero centavo
+money	en-GB	ars	123.456	one hundred and twenty-three Argentine pesos forty-six centavos
+money	en-GB	ars	1.005	one Argentine peso one centavo
+money	en-GB	brl	0	zero Brazilian real zero centavo
+money	en-GB	brl	0.01	zero Brazilian real one centavo
+money	en-GB	brl	0.02	zero Brazilian real two centavos
+money	en-GB	brl	1	one Brazilian real zero centavo
+money	en-GB	brl	1.01	one Brazilian real one centavo
+money	en-GB	brl	1.02	one Brazilian real two centavos
+money	en-GB	brl	2	two Brazilian reais zero centavo
+money	en-GB	brl	2.02	two Brazilian reais two centavos
+money	en-GB	brl	3	three Brazilian reais zero centavo
+money	en-GB	brl	5	five Brazilian reais zero centavo
+money	en-GB	brl	11	eleven Brazilian reais zero centavo
+money	en-GB	brl	21	twenty-one Brazilian reais zero centavo
+money	en-GB	brl	22	twenty-two Brazilian reais zero centavo
+money	en-GB	brl	42	forty-two Brazilian reais zero centavo
+money	en-GB	brl	100	one hundred Brazilian reais zero centavo
+money	en-GB	brl	101	one hundred and one Brazilian reais zero centavo
+money	en-GB	brl	121	one hundred and twenty-one Brazilian reais zero centavo
+money	en-GB	brl	999	nine hundred and ninety-nine Brazilian reais zero centavo
+money	en-GB	brl	1000	one thousand Brazilian reais zero centavo
+money	en-GB	brl	1001	one thousand and one Brazilian reais zero centavo
+money	en-GB	brl	2000	two thousand Brazilian reais zero centavo
+money	en-GB	brl	2001	two thousand and one Brazilian reais zero centavo
+money	en-GB	brl	5000	five thousand Brazilian reais zero centavo
+money	en-GB	brl	21000	twenty-one thousand Brazilian reais zero centavo
+money	en-GB	brl	22000	twenty-two thousand Brazilian reais zero centavo
+money	en-GB	brl	41000	forty-one thousand Brazilian reais zero centavo
+money	en-GB	brl	42000	forty-two thousand Brazilian reais zero centavo
+money	en-GB	brl	100000	one hundred thousand Brazilian reais zero centavo
+money	en-GB	brl	1000000	one million Brazilian reais zero centavo
+money	en-GB	brl	2000000	two million Brazilian reais zero centavo
+money	en-GB	brl	1000000000	one billion Brazilian reais zero centavo
+money	en-GB	brl	123.45	one hundred and twenty-three Brazilian reais forty-five centavos
+money	en-GB	brl	-1	minus one Brazilian real zero centavo
+money	en-GB	brl	-2	minus two Brazilian reais zero centavo
+money	en-GB	brl	-41.5	minus forty-one Brazilian reais fifty centavos
+money	en-GB	brl	-1000	minus one thousand Brazilian reais zero centavo
+money	en-GB	brl	1.999	two Brazilian reais zero centavo
+money	en-GB	brl	123.456	one hundred and twenty-three Brazilian reais forty-six centavos
+money	en-GB	brl	1.005	one Brazilian real one centavo
+money	en-GB	uzs	0	zero Uzbek som zero tiyin
+money	en-GB	uzs	0.01	zero Uzbek som one tiyin
+money	en-GB	uzs	0.02	zero Uzbek som two tiyin
+money	en-GB	uzs	1	one Uzbek som zero tiyin
+money	en-GB	uzs	1.01	one Uzbek som one tiyin
+money	en-GB	uzs	1.02	one Uzbek som two tiyin
+money	en-GB	uzs	2	two Uzbek som zero tiyin
+money	en-GB	uzs	2.02	two Uzbek som two tiyin
+money	en-GB	uzs	3	three Uzbek som zero tiyin
+money	en-GB	uzs	5	five Uzbek som zero tiyin
+money	en-GB	uzs	11	eleven Uzbek som zero tiyin
+money	en-GB	uzs	21	twenty-one Uzbek som zero tiyin
+money	en-GB	uzs	22	twenty-two Uzbek som zero tiyin
+money	en-GB	uzs	42	forty-two Uzbek som zero tiyin
+money	en-GB	uzs	100	one hundred Uzbek som zero tiyin
+money	en-GB	uzs	101	one hundred and one Uzbek som zero tiyin
+money	en-GB	uzs	121	one hundred and twenty-one Uzbek som zero tiyin
+money	en-GB	uzs	999	nine hundred and ninety-nine Uzbek som zero tiyin
+money	en-GB	uzs	1000	one thousand Uzbek som zero tiyin
+money	en-GB	uzs	1001	one thousand and one Uzbek som zero tiyin
+money	en-GB	uzs	2000	two thousand Uzbek som zero tiyin
+money	en-GB	uzs	2001	two thousand and one Uzbek som zero tiyin
+money	en-GB	uzs	5000	five thousand Uzbek som zero tiyin
+money	en-GB	uzs	21000	twenty-one thousand Uzbek som zero tiyin
+money	en-GB	uzs	22000	twenty-two thousand Uzbek som zero tiyin
+money	en-GB	uzs	41000	forty-one thousand Uzbek som zero tiyin
+money	en-GB	uzs	42000	forty-two thousand Uzbek som zero tiyin
+money	en-GB	uzs	100000	one hundred thousand Uzbek som zero tiyin
+money	en-GB	uzs	1000000	one million Uzbek som zero tiyin
+money	en-GB	uzs	2000000	two million Uzbek som zero tiyin
+money	en-GB	uzs	1000000000	one billion Uzbek som zero tiyin
+money	en-GB	uzs	123.45	one hundred and twenty-three Uzbek som forty-five tiyin
+money	en-GB	uzs	-1	minus one Uzbek som zero tiyin
+money	en-GB	uzs	-2	minus two Uzbek som zero tiyin
+money	en-GB	uzs	-41.5	minus forty-one Uzbek som fifty tiyin
+money	en-GB	uzs	-1000	minus one thousand Uzbek som zero tiyin
+money	en-GB	uzs	1.999	two Uzbek som zero tiyin
+money	en-GB	uzs	123.456	one hundred and twenty-three Uzbek som forty-six tiyin
+money	en-GB	uzs	1.005	one Uzbek som one tiyin
+money	en-GB	gbp	0	zero pound sterling zero penny
+money	en-GB	gbp	0.01	zero pound sterling one penny
+money	en-GB	gbp	0.02	zero pound sterling two pence
+money	en-GB	gbp	1	one pound sterling zero penny
+money	en-GB	gbp	1.01	one pound sterling one penny
+money	en-GB	gbp	1.02	one pound sterling two pence
+money	en-GB	gbp	2	two pounds sterling zero penny
+money	en-GB	gbp	2.02	two pounds sterling two pence
+money	en-GB	gbp	3	three pounds sterling zero penny
+money	en-GB	gbp	5	five pounds sterling zero penny
+money	en-GB	gbp	11	eleven pounds sterling zero penny
+money	en-GB	gbp	21	twenty-one pounds sterling zero penny
+money	en-GB	gbp	22	twenty-two pounds sterling zero penny
+money	en-GB	gbp	42	forty-two pounds sterling zero penny
+money	en-GB	gbp	100	one hundred pounds sterling zero penny
+money	en-GB	gbp	101	one hundred and one pounds sterling zero penny
+money	en-GB	gbp	121	one hundred and twenty-one pounds sterling zero penny
+money	en-GB	gbp	999	nine hundred and ninety-nine pounds sterling zero penny
+money	en-GB	gbp	1000	one thousand pounds sterling zero penny
+money	en-GB	gbp	1001	one thousand and one pounds sterling zero penny
+money	en-GB	gbp	2000	two thousand pounds sterling zero penny
+money	en-GB	gbp	2001	two thousand and one pounds sterling zero penny
+money	en-GB	gbp	5000	five thousand pounds sterling zero penny
+money	en-GB	gbp	21000	twenty-one thousand pounds sterling zero penny
+money	en-GB	gbp	22000	twenty-two thousand pounds sterling zero penny
+money	en-GB	gbp	41000	forty-one thousand pounds sterling zero penny
+money	en-GB	gbp	42000	forty-two thousand pounds sterling zero penny
+money	en-GB	gbp	100000	one hundred thousand pounds sterling zero penny
+money	en-GB	gbp	1000000	one million pounds sterling zero penny
+money	en-GB	gbp	2000000	two million pounds sterling zero penny
+money	en-GB	gbp	1000000000	one billion pounds sterling zero penny
+money	en-GB	gbp	123.45	one hundred and twenty-three pounds sterling forty-five pence
+money	en-GB	gbp	-1	minus one pound sterling zero penny
+money	en-GB	gbp	-2	minus two pounds sterling zero penny
+money	en-GB	gbp	-41.5	minus forty-one pounds sterling fifty pence
+money	en-GB	gbp	-1000	minus one thousand pounds sterling zero penny
+money	en-GB	gbp	1.999	two pounds sterling zero penny
+money	en-GB	gbp	123.456	one hundred and twenty-three pounds sterling forty-six pence
+money	en-GB	gbp	1.005	one pound sterling one penny

--- a/src/Nut/Extentions.cs
+++ b/src/Nut/Extentions.cs
@@ -20,7 +20,7 @@ namespace Nut
             {
                 { Language.English, EnglishConverter.Instance },
                 { Culture.EnglishUS, EnglishConverter.Instance },
-                { Culture.EnglishGB, EnglishConverter.Instance },
+                { Culture.EnglishGB, EnglishConverter.BritishInstance },
                 { Language.French, FrenchConverter.Instance },
                 { Culture.French, FrenchConverter.Instance },
                 { Language.German, GermanConverter.Instance },

--- a/src/Nut/TextConverters/EnglishConverter.cs
+++ b/src/Nut/TextConverters/EnglishConverter.cs
@@ -10,13 +10,45 @@ namespace Nut.TextConverters
         private static readonly Lazy<EnglishConverter> Lazy = new Lazy<EnglishConverter>(() => new EnglishConverter());
         public static EnglishConverter Instance => Lazy.Value;
 
-        public override string CultureName => Culture.EnglishUS;
+        private static readonly Lazy<EnglishConverter> LazyBritish =
+            new Lazy<EnglishConverter>(() => new EnglishConverter(true));
+
+        /// <summary>
+        /// British usage puts "and" before the last part when it is under a hundred:
+        /// "one hundred and one", "five thousand and twenty-six". American usage drops it.
+        /// Banks treat the written amount as the authoritative one, so the two are kept
+        /// apart rather than collapsed into one spelling.
+        /// </summary>
+        public static EnglishConverter BritishInstance => LazyBritish.Value;
+
+        private readonly bool _useAnd;
+
+        public override string CultureName => _useAnd ? Culture.EnglishGB : Culture.EnglishUS;
 
         protected override string NegativeSign => "minus";
 
         public EnglishConverter()
         {
             Initialize();
+        }
+
+        private EnglishConverter(bool useAnd)
+        {
+            _useAnd = useAnd;
+            Initialize();
+        }
+
+        /// <summary>
+        /// "and" goes in front of the final group when that group is under a hundred, so
+        /// "one hundred and one" and "five thousand and twenty-six", but "one hundred"
+        /// and "one thousand one hundred" take none.
+        /// </summary>
+        protected override void AppendLessThanOneThousand(long num, StringBuilder builder)
+        {
+            num = AppendHundreds(num, builder);
+            if (_useAnd && num > 0 && builder.Length > 0) builder.Append("and ");
+            num = AppendTens(num, builder);
+            AppendUnits(num, builder);
         }
 
         /// <summary>


### PR DESCRIPTION
`en-GB` and `en-US` resolved to the **same converter**, so asking for British English gave American wording.

| Number | `en-US` | `en-GB` |
|---|---|---|
| `101` | one hundred one | one hundred **and** one |
| `999` | nine hundred ninety-nine | nine hundred **and** ninety-nine |
| `1001` | one thousand one | one thousand **and** one |
| `5026` | five thousand twenty-six | five thousand **and** twenty-six |
| `1100` | one thousand one hundred | one thousand one hundred |

The "and" attaches to the final group only when that group is under a hundred, which is why `1100` and `100000` are identical in both.

## Why keep them apart rather than pick one

On a cheque the amount in words is the one the bank pays against — the figures are secondary. A British payer writing `en-GB` should get British wording, not a spelling that reads as foreign on a legal instrument. That is also why the hyphenation in #45 matters: cheque-writing guidance calls for it specifically, as a fraud-prevention measure, not just as style.

## Verification

- Only `en-GB` rows are added to the snapshot. **`en-US` and every other language are unchanged** — diffed for modified rows, zero.
- The two instances are genuinely separate objects with their own tables, so the British flag cannot leak into American output.
- 532 tests. The snapshot now covers `en-GB` as its own language.

## Review note

One existing test asserted `en-GB` → `one hundred one`, which I had written when the two were the same converter. It failed, correctly, and is updated.