### PR TITLE
fix: capitalise the sign, not the second word

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -115,6 +115,12 @@ assert on that text, review the tables below before taking this release.
 - **Portuguese** joins the two parts of an amount with `e` rather than `com`
   ([#27](https://github.com/emrahyumuk/NUT-number-to-text/pull/27)).
 
+- **Capitalisation no longer lands on the wrong word for a negative amount.**
+  `MainUnitFirstCharUpper` capitalised the main unit, which stopped being the first word
+  once the sign was added: `minus Forty-one dollars`. The sign takes the capital now —
+  `Minus forty-one dollars`. This matters on a cheque, where the amount in words is the
+  field the bank pays against.
+
 ### Changed
 
 - **Numbers past the supported range throw `ArgumentOutOfRangeException`** instead of a bare
@@ -217,6 +223,12 @@ correctness under concurrency and repeated calls, not wording.
 - Russian converter endings.
 
 ## [3.0.0] - 2020-07-03
+
+- **Capitalisation no longer lands on the wrong word for a negative amount.**
+  `MainUnitFirstCharUpper` capitalised the main unit, which stopped being the first word
+  once the sign was added: `minus Forty-one dollars`. The sign takes the capital now —
+  `Minus forty-one dollars`. This matters on a cheque, where the amount in words is the
+  field the bank pays against.
 
 ### Changed
 

--- a/src/Nut.Tests/CapitalisedNegatives.cs
+++ b/src/Nut.Tests/CapitalisedNegatives.cs
@@ -1,0 +1,54 @@
+namespace Nut.Tests
+{
+    /// <summary>
+    /// The amount-in-words field on a cheque or invoice is usually capitalised, and it is
+    /// the field the bank pays against. Capitalising the main unit put the capital on the
+    /// wrong word once a sign was in front of it: "minus Forty-one dollars".
+    /// </summary>
+    [TestFixture]
+    public class CapitalisedNegatives
+    {
+        private static Options Caps => new Options
+        {
+            MainUnitFirstCharUpper = true,
+            CurrencyFirstCharUpper = true,
+            SubUnitFirstCharUpper = true,
+        };
+
+        [TestCase(Language.English, Currency.USD, "Minus forty-one Dollars Fifty Cents")]
+        [TestCase(Language.Turkish, Currency.TRY, "Eksi kırk bir Türk lirası Elli Kuruş")]
+        [TestCase(Language.Russian, Currency.RUB, "Минус сорок один Рубль Пятьдесят Копеек")]
+        public void TheSignTakesTheCapital(string lang, string currency, string expected)
+        {
+            Assert.That((-41.5m).ToText(currency, lang, Caps), Is.EqualTo(expected));
+        }
+
+        [Test]
+        public void PositiveAmountsAreUnchanged()
+        {
+            Assert.That(41.5m.ToText(Currency.USD, Language.English, Caps),
+                Is.EqualTo("Forty-one Dollars Fifty Cents"));
+        }
+
+        /// <summary>Without the option, nothing is capitalised — including the sign.</summary>
+        [Test]
+        public void NoCapitalWhenNoneIsAskedFor()
+        {
+            Assert.That((-41.5m).ToText(Currency.USD, Language.English),
+                Is.EqualTo("minus forty-one dollars fifty cents"));
+        }
+
+        /// <summary>Exactly one capital at the start, never two.</summary>
+        [TestCase(Language.English, Currency.USD)]
+        [TestCase(Language.Uzbek, Currency.UZS)]
+        [TestCase(Language.Russian, Currency.RUB)]
+        public void OnlyTheFirstWordIsCapitalised(string lang, string currency)
+        {
+            var text = (-41.5m).ToText(currency, lang, new Options { MainUnitFirstCharUpper = true });
+            var words = text.Split(' ');
+            Assert.That(char.IsUpper(words[0][0]), Is.True, "first word should be capitalised");
+            Assert.That(words[1], Is.EqualTo(words[1].ToLowerInvariant()),
+                "the word after the sign should not be capitalised");
+        }
+    }
+}

--- a/src/Nut/TextConverters/BaseConverter.cs
+++ b/src/Nut/TextConverters/BaseConverter.cs
@@ -196,7 +196,12 @@ namespace Nut.TextConverters
       else
       {
         var mainUnitText = ToText(mainUnitNum, currencyModel, true);
-        mainUnitText = options.MainUnitFirstCharUpper ? mainUnitText.ToFirstLetterUpper(CultureName) : mainUnitText;
+        // Only capitalise here when this really is the first word. On a negative amount
+        // the sign comes first, so capitalising the main unit would put the capital in the
+        // middle: "minus Forty-one dollars" instead of "Minus forty-one dollars".
+        mainUnitText = options.MainUnitFirstCharUpper && !isNegative
+          ? mainUnitText.ToFirstLetterUpper(CultureName)
+          : mainUnitText;
         builder.Append(mainUnitText);
       }
 
@@ -236,7 +241,10 @@ namespace Nut.TextConverters
       }
 
       var text = builder.ToString().Trim();
-      return isNegative ? NegativeSign + " " + text : text;
+      if (!isNegative) return text;
+
+      var sign = options.MainUnitFirstCharUpper ? NegativeSign.ToFirstLetterUpper(CultureName) : NegativeSign;
+      return sign + " " + text;
     }
 
     protected virtual string GetCurrencyText(long num, CurrencyModel currency)


### PR DESCRIPTION
`MainUnitFirstCharUpper` capitalises the main unit — which is the first word only when the amount is positive.

```
before   minus Forty-one Dollars Fifty Cents
after    Minus forty-one Dollars Fifty Cents
```

The capital now goes on whichever word actually comes first.

## Why it matters here

The amount-in-words field is what a bank pays against, and it is normally capitalised. A capital sitting in the middle of that field reads as a mistake on the document, which is exactly what you do not want on an instrument whose whole purpose is to be unambiguous.

## Verification

- Positive amounts unchanged: `Forty-one Dollars Fifty Cents`.
- With the option off, nothing is capitalised, sign included.
- A test asserts there is exactly one capital and that the word after the sign is lower case, across English, Uzbek and Russian.
- Snapshot untouched — it renders with default options, so no conversion in it changes.
- 540 tests.

## Credit

This came out of the review you had run over the package from a financial-documents angle. I would not have looked at capitalisation on its own — it only shows up when you picture the string printed in the "amount in words" box rather than reading it as a return value.