### PR TITLE
feat: add Latvian

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -144,6 +144,12 @@ assert on that text, review the tables below before taking this release.
   it is added here — in French the distinction carries meaning, since *le livre* is a book
   and *la livre* the currency.
 
+- **Latvian**, from
+  [#24](https://github.com/emrahyumuk/NUT-number-to-text/pull/24). Numerals agree in
+  gender (`viens eiro` but `viena mārciņa`), and the unit name takes three forms: singular
+  after a count ending in one, genitive plural after zero (`nulle centu`), plural
+  otherwise.
+
 - **Uzbek (Latin script)** and the Uzbek som (`UZS`), from
   [#23](https://github.com/emrahyumuk/NUT-number-to-text/pull/23). The number system builds
   from twenty-two basic words and behaves like Turkish: no "bir" before *yuz* or *ming*.

--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@ Number To Text Converter
 
 Money To Text Converter
 
-**Supported Languages:** English, French, German, Russian, Spanish, Turkish, Ukrainian, Bulgarian, Amharic, Polish, Belarussian, Portuguese, Uzbek.
+**Supported Languages:** English, French, German, Russian, Spanish, Turkish, Ukrainian, Bulgarian, Amharic, Polish, Belarussian, Portuguese, Uzbek, Latvian.
 
 **Supported Currencies:** EUR, USD, GBP, RUB, TRY, UAH, BGN, ETB, PLN, BYN, ARS, BRL, UZS.
 
@@ -110,7 +110,7 @@ Pull requests are welcome. Two things make them much easier to accept:
 - [ArkadiuszMakosa](https://github.com/ArkadiuszMakosa) - Polish Language Unit Tests
 - [Maryam1986](https://github.com/Maryam1986) - German Language and Currency
 - [Furqat-Abduvosiqov](https://github.com/Furqat-Abduvosiqov) - Uzbek Language and Currency
-- [IlyashenkoA](https://github.com/IlyashenkoA) - GBP Currency
+- [IlyashenkoA](https://github.com/IlyashenkoA) - GBP Currency, Latvian Language
 
 ---
 

--- a/src/Nut.Tests/BehaviourSnapshot.cs
+++ b/src/Nut.Tests/BehaviourSnapshot.cs
@@ -27,7 +27,7 @@ namespace Nut.Tests
             Language.English, Language.French, Language.German, Language.Spanish,
             Language.Portuguese, Language.Turkish, Language.Russian, Language.Ukrainian,
             Language.Belarusian, Language.Bulgarian, Language.Polish, Language.Amharic,
-            Language.Uzbek, Culture.EnglishGB,
+            Language.Uzbek, Language.Latvian, Culture.EnglishGB,
         };
 
         private static readonly string[] Currencies =

--- a/src/Nut.Tests/LatvianNumerals.cs
+++ b/src/Nut.Tests/LatvianNumerals.cs
@@ -1,0 +1,67 @@
+namespace Nut.Tests
+{
+    /// <summary>
+    /// Latvian, from <see href="https://github.com/emrahyumuk/NUT-number-to-text/pull/24">#24</see>.
+    /// Numerals agree in gender with what they count, and the unit name takes three forms:
+    /// singular after a count ending in one, genitive plural after zero, plural otherwise.
+    /// </summary>
+    [TestFixture]
+    public class LatvianNumerals
+    {
+        [TestCase(0, "nulle")]
+        [TestCase(1, "viens")]
+        [TestCase(2, "divi")]
+        [TestCase(11, "vienpadsmit")]
+        [TestCase(21, "divdesmit viens")]
+        [TestCase(100, "simts")]
+        [TestCase(200, "divi simti")]
+        [TestCase(1000, "viens tūkstotis")]
+        [TestCase(2000, "divi tūkstoši")]
+        [TestCase(5000, "pieci tūkstoši")]
+        [TestCase(1234, "viens tūkstotis divi simti trīsdesmit četri")]
+        [TestCase(1000000, "viens miljons")]
+        public void Numbers(long number, string expected)
+        {
+            Assert.That(number.ToText(Language.Latvian), Is.EqualTo(expected));
+        }
+
+        /// <summary>Zero takes the genitive plural: "nulle centu", not "nulle centi".</summary>
+        [TestCase(1, "viens eiro un nulle centu")]
+        [TestCase(2, "divi eiro un nulle centu")]
+        [TestCase(21, "divdesmit viens eiro un nulle centu")]
+        [TestCase(1000, "viens tūkstotis eiro un nulle centu")]
+        [TestCase(1234.56, "viens tūkstotis divi simti trīsdesmit četri eiro un piecdesmit seši centi")]
+        public void Euro(decimal amount, string expected)
+        {
+            Assert.That(amount.ToText(Currency.EUR, Language.Latvian), Is.EqualTo(expected));
+        }
+
+        /// <summary>mārciņa is feminine, so the numeral agrees.</summary>
+        [TestCase(1, "viena sterliņu mārciņa un nulle pensu")]
+        [TestCase(2, "divas sterliņu mārciņas un nulle pensu")]
+        [TestCase(21, "divdesmit viena sterliņu mārciņa un nulle pensu")]
+        public void PoundIsFeminine(decimal amount, string expected)
+        {
+            Assert.That(amount.ToText(Currency.GBP, Language.Latvian), Is.EqualTo(expected));
+        }
+
+        /// <summary>Singular after a count ending in one — including 21 — but not after
+        /// eleven, where the -teen blocks it.</summary>
+        [TestCase(1, "cents")]
+        [TestCase(21, "cents")]
+        [TestCase(11, "centi")]
+        [TestCase(2, "centi")]
+        public void SubUnitInflection(int cents, string expectedWord)
+        {
+            var amount = 1m + cents / 100m;
+            Assert.That(amount.ToText(Currency.EUR, Language.Latvian), Does.EndWith(expectedWord));
+        }
+
+        [Test]
+        public void GeneralBehaviourApplies()
+        {
+            Assert.That((-41L).ToText(Language.Latvian), Is.EqualTo("mīnus četrdesmit viens"));
+            Assert.That(101.ToText(Culture.Latvian), Is.EqualTo("simts viens"));
+        }
+    }
+}

--- a/src/Nut.Tests/behaviour-snapshot.tsv
+++ b/src/Nut.Tests/behaviour-snapshot.tsv
@@ -6992,6 +6992,544 @@ money	uz	gbp	-1000	minus ming funt sterling nol pens
 money	uz	gbp	1.999	ikki funt sterling nol pens
 money	uz	gbp	123.456	yuz yigirma uch funt sterling qirq olti pens
 money	uz	gbp	1.005	bir funt sterling bir pens
+plain	lv	0	nulle
+plain	lv	1	viens
+plain	lv	2	divi
+plain	lv	3	trīs
+plain	lv	5	pieci
+plain	lv	11	vienpadsmit
+plain	lv	15	piecpadsmit
+plain	lv	20	divdesmit
+plain	lv	21	divdesmit viens
+plain	lv	22	divdesmit divi
+plain	lv	42	četrdesmit divi
+plain	lv	100	simts
+plain	lv	101	simts viens
+plain	lv	121	simts divdesmit viens
+plain	lv	200	divi simti
+plain	lv	999	deviņi simti deviņdesmit deviņi
+plain	lv	1000	viens tūkstotis
+plain	lv	1001	viens tūkstotis viens
+plain	lv	2000	divi tūkstoši
+plain	lv	5000	pieci tūkstoši
+plain	lv	21000	divdesmit viens tūkstoši
+plain	lv	41000	četrdesmit viens tūkstoši
+plain	lv	100000	simts tūkstoši
+plain	lv	1000000	viens miljons
+plain	lv	2000000	divi miljoni
+plain	lv	999999999	deviņi simti deviņdesmit deviņi miljoni deviņi simti deviņdesmit deviņi tūkstoši deviņi simti deviņdesmit deviņi
+plain	lv	-1	mīnus viens
+plain	lv	-2	mīnus divi
+plain	lv	-41	mīnus četrdesmit viens
+plain	lv	-1000	mīnus viens tūkstotis
+plain	lv	-1000000	mīnus viens miljons
+money	lv	eur	0	nulle eiro un nulle centu
+money	lv	eur	0.01	nulle eiro un viens cents
+money	lv	eur	0.02	nulle eiro un divi centi
+money	lv	eur	1	viens eiro un nulle centu
+money	lv	eur	1.01	viens eiro un viens cents
+money	lv	eur	1.02	viens eiro un divi centi
+money	lv	eur	2	divi eiro un nulle centu
+money	lv	eur	2.02	divi eiro un divi centi
+money	lv	eur	3	trīs eiro un nulle centu
+money	lv	eur	5	pieci eiro un nulle centu
+money	lv	eur	11	vienpadsmit eiro un nulle centu
+money	lv	eur	21	divdesmit viens eiro un nulle centu
+money	lv	eur	22	divdesmit divi eiro un nulle centu
+money	lv	eur	42	četrdesmit divi eiro un nulle centu
+money	lv	eur	100	simts eiro un nulle centu
+money	lv	eur	101	simts viens eiro un nulle centu
+money	lv	eur	121	simts divdesmit viens eiro un nulle centu
+money	lv	eur	999	deviņi simti deviņdesmit deviņi eiro un nulle centu
+money	lv	eur	1000	viens tūkstotis eiro un nulle centu
+money	lv	eur	1001	viens tūkstotis viens eiro un nulle centu
+money	lv	eur	2000	divi tūkstoši eiro un nulle centu
+money	lv	eur	2001	divi tūkstoši viens eiro un nulle centu
+money	lv	eur	5000	pieci tūkstoši eiro un nulle centu
+money	lv	eur	21000	divdesmit viens tūkstoši eiro un nulle centu
+money	lv	eur	22000	divdesmit divi tūkstoši eiro un nulle centu
+money	lv	eur	41000	četrdesmit viens tūkstoši eiro un nulle centu
+money	lv	eur	42000	četrdesmit divi tūkstoši eiro un nulle centu
+money	lv	eur	100000	simts tūkstoši eiro un nulle centu
+money	lv	eur	1000000	viens miljons eiro un nulle centu
+money	lv	eur	2000000	divi miljoni eiro un nulle centu
+money	lv	eur	1000000000	viens miljards eiro un nulle centu
+money	lv	eur	123.45	simts divdesmit trīs eiro un četrdesmit pieci centi
+money	lv	eur	-1	mīnus viens eiro un nulle centu
+money	lv	eur	-2	mīnus divi eiro un nulle centu
+money	lv	eur	-41.5	mīnus četrdesmit viens eiro un piecdesmit centi
+money	lv	eur	-1000	mīnus viens tūkstotis eiro un nulle centu
+money	lv	eur	1.999	divi eiro un nulle centu
+money	lv	eur	123.456	simts divdesmit trīs eiro un četrdesmit seši centi
+money	lv	eur	1.005	viens eiro un viens cents
+money	lv	usd	0	nulle ASV dolāru un nulle centu
+money	lv	usd	0.01	nulle ASV dolāru un viens cents
+money	lv	usd	0.02	nulle ASV dolāru un divi centi
+money	lv	usd	1	viens ASV dolārs un nulle centu
+money	lv	usd	1.01	viens ASV dolārs un viens cents
+money	lv	usd	1.02	viens ASV dolārs un divi centi
+money	lv	usd	2	divi ASV dolāri un nulle centu
+money	lv	usd	2.02	divi ASV dolāri un divi centi
+money	lv	usd	3	trīs ASV dolāri un nulle centu
+money	lv	usd	5	pieci ASV dolāri un nulle centu
+money	lv	usd	11	vienpadsmit ASV dolāri un nulle centu
+money	lv	usd	21	divdesmit viens ASV dolārs un nulle centu
+money	lv	usd	22	divdesmit divi ASV dolāri un nulle centu
+money	lv	usd	42	četrdesmit divi ASV dolāri un nulle centu
+money	lv	usd	100	simts ASV dolāri un nulle centu
+money	lv	usd	101	simts viens ASV dolārs un nulle centu
+money	lv	usd	121	simts divdesmit viens ASV dolārs un nulle centu
+money	lv	usd	999	deviņi simti deviņdesmit deviņi ASV dolāri un nulle centu
+money	lv	usd	1000	viens tūkstotis ASV dolāri un nulle centu
+money	lv	usd	1001	viens tūkstotis viens ASV dolārs un nulle centu
+money	lv	usd	2000	divi tūkstoši ASV dolāri un nulle centu
+money	lv	usd	2001	divi tūkstoši viens ASV dolārs un nulle centu
+money	lv	usd	5000	pieci tūkstoši ASV dolāri un nulle centu
+money	lv	usd	21000	divdesmit viens tūkstoši ASV dolāri un nulle centu
+money	lv	usd	22000	divdesmit divi tūkstoši ASV dolāri un nulle centu
+money	lv	usd	41000	četrdesmit viens tūkstoši ASV dolāri un nulle centu
+money	lv	usd	42000	četrdesmit divi tūkstoši ASV dolāri un nulle centu
+money	lv	usd	100000	simts tūkstoši ASV dolāri un nulle centu
+money	lv	usd	1000000	viens miljons ASV dolāri un nulle centu
+money	lv	usd	2000000	divi miljoni ASV dolāri un nulle centu
+money	lv	usd	1000000000	viens miljards ASV dolāri un nulle centu
+money	lv	usd	123.45	simts divdesmit trīs ASV dolāri un četrdesmit pieci centi
+money	lv	usd	-1	mīnus viens ASV dolārs un nulle centu
+money	lv	usd	-2	mīnus divi ASV dolāri un nulle centu
+money	lv	usd	-41.5	mīnus četrdesmit viens ASV dolārs un piecdesmit centi
+money	lv	usd	-1000	mīnus viens tūkstotis ASV dolāri un nulle centu
+money	lv	usd	1.999	divi ASV dolāri un nulle centu
+money	lv	usd	123.456	simts divdesmit trīs ASV dolāri un četrdesmit seši centi
+money	lv	usd	1.005	viens ASV dolārs un viens cents
+money	lv	rub	0	nulle Krievijas rubļu un nulle kapeiku
+money	lv	rub	0.01	nulle Krievijas rubļu un viena kapeika
+money	lv	rub	0.02	nulle Krievijas rubļu un divas kapeikas
+money	lv	rub	1	viens Krievijas rublis un nulle kapeiku
+money	lv	rub	1.01	viens Krievijas rublis un viena kapeika
+money	lv	rub	1.02	viens Krievijas rublis un divas kapeikas
+money	lv	rub	2	divi Krievijas rubļi un nulle kapeiku
+money	lv	rub	2.02	divi Krievijas rubļi un divas kapeikas
+money	lv	rub	3	trīs Krievijas rubļi un nulle kapeiku
+money	lv	rub	5	pieci Krievijas rubļi un nulle kapeiku
+money	lv	rub	11	vienpadsmit Krievijas rubļi un nulle kapeiku
+money	lv	rub	21	divdesmit viens Krievijas rublis un nulle kapeiku
+money	lv	rub	22	divdesmit divi Krievijas rubļi un nulle kapeiku
+money	lv	rub	42	četrdesmit divi Krievijas rubļi un nulle kapeiku
+money	lv	rub	100	simts Krievijas rubļi un nulle kapeiku
+money	lv	rub	101	simts viens Krievijas rublis un nulle kapeiku
+money	lv	rub	121	simts divdesmit viens Krievijas rublis un nulle kapeiku
+money	lv	rub	999	deviņi simti deviņdesmit deviņi Krievijas rubļi un nulle kapeiku
+money	lv	rub	1000	viens tūkstotis Krievijas rubļi un nulle kapeiku
+money	lv	rub	1001	viens tūkstotis viens Krievijas rublis un nulle kapeiku
+money	lv	rub	2000	divi tūkstoši Krievijas rubļi un nulle kapeiku
+money	lv	rub	2001	divi tūkstoši viens Krievijas rublis un nulle kapeiku
+money	lv	rub	5000	pieci tūkstoši Krievijas rubļi un nulle kapeiku
+money	lv	rub	21000	divdesmit viens tūkstoši Krievijas rubļi un nulle kapeiku
+money	lv	rub	22000	divdesmit divi tūkstoši Krievijas rubļi un nulle kapeiku
+money	lv	rub	41000	četrdesmit viens tūkstoši Krievijas rubļi un nulle kapeiku
+money	lv	rub	42000	četrdesmit divi tūkstoši Krievijas rubļi un nulle kapeiku
+money	lv	rub	100000	simts tūkstoši Krievijas rubļi un nulle kapeiku
+money	lv	rub	1000000	viens miljons Krievijas rubļi un nulle kapeiku
+money	lv	rub	2000000	divi miljoni Krievijas rubļi un nulle kapeiku
+money	lv	rub	1000000000	viens miljards Krievijas rubļi un nulle kapeiku
+money	lv	rub	123.45	simts divdesmit trīs Krievijas rubļi un četrdesmit pieci kapeikas
+money	lv	rub	-1	mīnus viens Krievijas rublis un nulle kapeiku
+money	lv	rub	-2	mīnus divi Krievijas rubļi un nulle kapeiku
+money	lv	rub	-41.5	mīnus četrdesmit viens Krievijas rublis un piecdesmit kapeikas
+money	lv	rub	-1000	mīnus viens tūkstotis Krievijas rubļi un nulle kapeiku
+money	lv	rub	1.999	divi Krievijas rubļi un nulle kapeiku
+money	lv	rub	123.456	simts divdesmit trīs Krievijas rubļi un četrdesmit seši kapeikas
+money	lv	rub	1.005	viens Krievijas rublis un viena kapeika
+money	lv	try	0	
+money	lv	try	0.01	
+money	lv	try	0.02	
+money	lv	try	1	
+money	lv	try	1.01	
+money	lv	try	1.02	
+money	lv	try	2	
+money	lv	try	2.02	
+money	lv	try	3	
+money	lv	try	5	
+money	lv	try	11	
+money	lv	try	21	
+money	lv	try	22	
+money	lv	try	42	
+money	lv	try	100	
+money	lv	try	101	
+money	lv	try	121	
+money	lv	try	999	
+money	lv	try	1000	
+money	lv	try	1001	
+money	lv	try	2000	
+money	lv	try	2001	
+money	lv	try	5000	
+money	lv	try	21000	
+money	lv	try	22000	
+money	lv	try	41000	
+money	lv	try	42000	
+money	lv	try	100000	
+money	lv	try	1000000	
+money	lv	try	2000000	
+money	lv	try	1000000000	
+money	lv	try	123.45	
+money	lv	try	-1	
+money	lv	try	-2	
+money	lv	try	-41.5	
+money	lv	try	-1000	
+money	lv	try	1.999	
+money	lv	try	123.456	
+money	lv	try	1.005	
+money	lv	uah	0	
+money	lv	uah	0.01	
+money	lv	uah	0.02	
+money	lv	uah	1	
+money	lv	uah	1.01	
+money	lv	uah	1.02	
+money	lv	uah	2	
+money	lv	uah	2.02	
+money	lv	uah	3	
+money	lv	uah	5	
+money	lv	uah	11	
+money	lv	uah	21	
+money	lv	uah	22	
+money	lv	uah	42	
+money	lv	uah	100	
+money	lv	uah	101	
+money	lv	uah	121	
+money	lv	uah	999	
+money	lv	uah	1000	
+money	lv	uah	1001	
+money	lv	uah	2000	
+money	lv	uah	2001	
+money	lv	uah	5000	
+money	lv	uah	21000	
+money	lv	uah	22000	
+money	lv	uah	41000	
+money	lv	uah	42000	
+money	lv	uah	100000	
+money	lv	uah	1000000	
+money	lv	uah	2000000	
+money	lv	uah	1000000000	
+money	lv	uah	123.45	
+money	lv	uah	-1	
+money	lv	uah	-2	
+money	lv	uah	-41.5	
+money	lv	uah	-1000	
+money	lv	uah	1.999	
+money	lv	uah	123.456	
+money	lv	uah	1.005	
+money	lv	bgn	0	
+money	lv	bgn	0.01	
+money	lv	bgn	0.02	
+money	lv	bgn	1	
+money	lv	bgn	1.01	
+money	lv	bgn	1.02	
+money	lv	bgn	2	
+money	lv	bgn	2.02	
+money	lv	bgn	3	
+money	lv	bgn	5	
+money	lv	bgn	11	
+money	lv	bgn	21	
+money	lv	bgn	22	
+money	lv	bgn	42	
+money	lv	bgn	100	
+money	lv	bgn	101	
+money	lv	bgn	121	
+money	lv	bgn	999	
+money	lv	bgn	1000	
+money	lv	bgn	1001	
+money	lv	bgn	2000	
+money	lv	bgn	2001	
+money	lv	bgn	5000	
+money	lv	bgn	21000	
+money	lv	bgn	22000	
+money	lv	bgn	41000	
+money	lv	bgn	42000	
+money	lv	bgn	100000	
+money	lv	bgn	1000000	
+money	lv	bgn	2000000	
+money	lv	bgn	1000000000	
+money	lv	bgn	123.45	
+money	lv	bgn	-1	
+money	lv	bgn	-2	
+money	lv	bgn	-41.5	
+money	lv	bgn	-1000	
+money	lv	bgn	1.999	
+money	lv	bgn	123.456	
+money	lv	bgn	1.005	
+money	lv	etb	0	
+money	lv	etb	0.01	
+money	lv	etb	0.02	
+money	lv	etb	1	
+money	lv	etb	1.01	
+money	lv	etb	1.02	
+money	lv	etb	2	
+money	lv	etb	2.02	
+money	lv	etb	3	
+money	lv	etb	5	
+money	lv	etb	11	
+money	lv	etb	21	
+money	lv	etb	22	
+money	lv	etb	42	
+money	lv	etb	100	
+money	lv	etb	101	
+money	lv	etb	121	
+money	lv	etb	999	
+money	lv	etb	1000	
+money	lv	etb	1001	
+money	lv	etb	2000	
+money	lv	etb	2001	
+money	lv	etb	5000	
+money	lv	etb	21000	
+money	lv	etb	22000	
+money	lv	etb	41000	
+money	lv	etb	42000	
+money	lv	etb	100000	
+money	lv	etb	1000000	
+money	lv	etb	2000000	
+money	lv	etb	1000000000	
+money	lv	etb	123.45	
+money	lv	etb	-1	
+money	lv	etb	-2	
+money	lv	etb	-41.5	
+money	lv	etb	-1000	
+money	lv	etb	1.999	
+money	lv	etb	123.456	
+money	lv	etb	1.005	
+money	lv	pln	0	nulle Polijas zlotu un nulle grašu
+money	lv	pln	0.01	nulle Polijas zlotu un viens grasis
+money	lv	pln	0.02	nulle Polijas zlotu un divi graši
+money	lv	pln	1	viens Polijas zlots un nulle grašu
+money	lv	pln	1.01	viens Polijas zlots un viens grasis
+money	lv	pln	1.02	viens Polijas zlots un divi graši
+money	lv	pln	2	divi Polijas zloti un nulle grašu
+money	lv	pln	2.02	divi Polijas zloti un divi graši
+money	lv	pln	3	trīs Polijas zloti un nulle grašu
+money	lv	pln	5	pieci Polijas zloti un nulle grašu
+money	lv	pln	11	vienpadsmit Polijas zloti un nulle grašu
+money	lv	pln	21	divdesmit viens Polijas zlots un nulle grašu
+money	lv	pln	22	divdesmit divi Polijas zloti un nulle grašu
+money	lv	pln	42	četrdesmit divi Polijas zloti un nulle grašu
+money	lv	pln	100	simts Polijas zloti un nulle grašu
+money	lv	pln	101	simts viens Polijas zlots un nulle grašu
+money	lv	pln	121	simts divdesmit viens Polijas zlots un nulle grašu
+money	lv	pln	999	deviņi simti deviņdesmit deviņi Polijas zloti un nulle grašu
+money	lv	pln	1000	viens tūkstotis Polijas zloti un nulle grašu
+money	lv	pln	1001	viens tūkstotis viens Polijas zlots un nulle grašu
+money	lv	pln	2000	divi tūkstoši Polijas zloti un nulle grašu
+money	lv	pln	2001	divi tūkstoši viens Polijas zlots un nulle grašu
+money	lv	pln	5000	pieci tūkstoši Polijas zloti un nulle grašu
+money	lv	pln	21000	divdesmit viens tūkstoši Polijas zloti un nulle grašu
+money	lv	pln	22000	divdesmit divi tūkstoši Polijas zloti un nulle grašu
+money	lv	pln	41000	četrdesmit viens tūkstoši Polijas zloti un nulle grašu
+money	lv	pln	42000	četrdesmit divi tūkstoši Polijas zloti un nulle grašu
+money	lv	pln	100000	simts tūkstoši Polijas zloti un nulle grašu
+money	lv	pln	1000000	viens miljons Polijas zloti un nulle grašu
+money	lv	pln	2000000	divi miljoni Polijas zloti un nulle grašu
+money	lv	pln	1000000000	viens miljards Polijas zloti un nulle grašu
+money	lv	pln	123.45	simts divdesmit trīs Polijas zloti un četrdesmit pieci graši
+money	lv	pln	-1	mīnus viens Polijas zlots un nulle grašu
+money	lv	pln	-2	mīnus divi Polijas zloti un nulle grašu
+money	lv	pln	-41.5	mīnus četrdesmit viens Polijas zlots un piecdesmit graši
+money	lv	pln	-1000	mīnus viens tūkstotis Polijas zloti un nulle grašu
+money	lv	pln	1.999	divi Polijas zloti un nulle grašu
+money	lv	pln	123.456	simts divdesmit trīs Polijas zloti un četrdesmit seši graši
+money	lv	pln	1.005	viens Polijas zlots un viens grasis
+money	lv	byn	0	
+money	lv	byn	0.01	
+money	lv	byn	0.02	
+money	lv	byn	1	
+money	lv	byn	1.01	
+money	lv	byn	1.02	
+money	lv	byn	2	
+money	lv	byn	2.02	
+money	lv	byn	3	
+money	lv	byn	5	
+money	lv	byn	11	
+money	lv	byn	21	
+money	lv	byn	22	
+money	lv	byn	42	
+money	lv	byn	100	
+money	lv	byn	101	
+money	lv	byn	121	
+money	lv	byn	999	
+money	lv	byn	1000	
+money	lv	byn	1001	
+money	lv	byn	2000	
+money	lv	byn	2001	
+money	lv	byn	5000	
+money	lv	byn	21000	
+money	lv	byn	22000	
+money	lv	byn	41000	
+money	lv	byn	42000	
+money	lv	byn	100000	
+money	lv	byn	1000000	
+money	lv	byn	2000000	
+money	lv	byn	1000000000	
+money	lv	byn	123.45	
+money	lv	byn	-1	
+money	lv	byn	-2	
+money	lv	byn	-41.5	
+money	lv	byn	-1000	
+money	lv	byn	1.999	
+money	lv	byn	123.456	
+money	lv	byn	1.005	
+money	lv	ars	0	
+money	lv	ars	0.01	
+money	lv	ars	0.02	
+money	lv	ars	1	
+money	lv	ars	1.01	
+money	lv	ars	1.02	
+money	lv	ars	2	
+money	lv	ars	2.02	
+money	lv	ars	3	
+money	lv	ars	5	
+money	lv	ars	11	
+money	lv	ars	21	
+money	lv	ars	22	
+money	lv	ars	42	
+money	lv	ars	100	
+money	lv	ars	101	
+money	lv	ars	121	
+money	lv	ars	999	
+money	lv	ars	1000	
+money	lv	ars	1001	
+money	lv	ars	2000	
+money	lv	ars	2001	
+money	lv	ars	5000	
+money	lv	ars	21000	
+money	lv	ars	22000	
+money	lv	ars	41000	
+money	lv	ars	42000	
+money	lv	ars	100000	
+money	lv	ars	1000000	
+money	lv	ars	2000000	
+money	lv	ars	1000000000	
+money	lv	ars	123.45	
+money	lv	ars	-1	
+money	lv	ars	-2	
+money	lv	ars	-41.5	
+money	lv	ars	-1000	
+money	lv	ars	1.999	
+money	lv	ars	123.456	
+money	lv	ars	1.005	
+money	lv	brl	0	
+money	lv	brl	0.01	
+money	lv	brl	0.02	
+money	lv	brl	1	
+money	lv	brl	1.01	
+money	lv	brl	1.02	
+money	lv	brl	2	
+money	lv	brl	2.02	
+money	lv	brl	3	
+money	lv	brl	5	
+money	lv	brl	11	
+money	lv	brl	21	
+money	lv	brl	22	
+money	lv	brl	42	
+money	lv	brl	100	
+money	lv	brl	101	
+money	lv	brl	121	
+money	lv	brl	999	
+money	lv	brl	1000	
+money	lv	brl	1001	
+money	lv	brl	2000	
+money	lv	brl	2001	
+money	lv	brl	5000	
+money	lv	brl	21000	
+money	lv	brl	22000	
+money	lv	brl	41000	
+money	lv	brl	42000	
+money	lv	brl	100000	
+money	lv	brl	1000000	
+money	lv	brl	2000000	
+money	lv	brl	1000000000	
+money	lv	brl	123.45	
+money	lv	brl	-1	
+money	lv	brl	-2	
+money	lv	brl	-41.5	
+money	lv	brl	-1000	
+money	lv	brl	1.999	
+money	lv	brl	123.456	
+money	lv	brl	1.005	
+money	lv	uzs	0	
+money	lv	uzs	0.01	
+money	lv	uzs	0.02	
+money	lv	uzs	1	
+money	lv	uzs	1.01	
+money	lv	uzs	1.02	
+money	lv	uzs	2	
+money	lv	uzs	2.02	
+money	lv	uzs	3	
+money	lv	uzs	5	
+money	lv	uzs	11	
+money	lv	uzs	21	
+money	lv	uzs	22	
+money	lv	uzs	42	
+money	lv	uzs	100	
+money	lv	uzs	101	
+money	lv	uzs	121	
+money	lv	uzs	999	
+money	lv	uzs	1000	
+money	lv	uzs	1001	
+money	lv	uzs	2000	
+money	lv	uzs	2001	
+money	lv	uzs	5000	
+money	lv	uzs	21000	
+money	lv	uzs	22000	
+money	lv	uzs	41000	
+money	lv	uzs	42000	
+money	lv	uzs	100000	
+money	lv	uzs	1000000	
+money	lv	uzs	2000000	
+money	lv	uzs	1000000000	
+money	lv	uzs	123.45	
+money	lv	uzs	-1	
+money	lv	uzs	-2	
+money	lv	uzs	-41.5	
+money	lv	uzs	-1000	
+money	lv	uzs	1.999	
+money	lv	uzs	123.456	
+money	lv	uzs	1.005	
+money	lv	gbp	0	nulle sterliņu mārciņu un nulle pensu
+money	lv	gbp	0.01	nulle sterliņu mārciņu un viens penss
+money	lv	gbp	0.02	nulle sterliņu mārciņu un divi pensi
+money	lv	gbp	1	viena sterliņu mārciņa un nulle pensu
+money	lv	gbp	1.01	viena sterliņu mārciņa un viens penss
+money	lv	gbp	1.02	viena sterliņu mārciņa un divi pensi
+money	lv	gbp	2	divas sterliņu mārciņas un nulle pensu
+money	lv	gbp	2.02	divas sterliņu mārciņas un divi pensi
+money	lv	gbp	3	trīs sterliņu mārciņas un nulle pensu
+money	lv	gbp	5	pieci sterliņu mārciņas un nulle pensu
+money	lv	gbp	11	vienpadsmit sterliņu mārciņas un nulle pensu
+money	lv	gbp	21	divdesmit viena sterliņu mārciņa un nulle pensu
+money	lv	gbp	22	divdesmit divas sterliņu mārciņas un nulle pensu
+money	lv	gbp	42	četrdesmit divas sterliņu mārciņas un nulle pensu
+money	lv	gbp	100	simts sterliņu mārciņas un nulle pensu
+money	lv	gbp	101	simts viena sterliņu mārciņa un nulle pensu
+money	lv	gbp	121	simts divdesmit viena sterliņu mārciņa un nulle pensu
+money	lv	gbp	999	deviņi simti deviņdesmit deviņi sterliņu mārciņas un nulle pensu
+money	lv	gbp	1000	viena tūkstotis sterliņu mārciņas un nulle pensu
+money	lv	gbp	1001	viena tūkstotis viena sterliņu mārciņa un nulle pensu
+money	lv	gbp	2000	divas tūkstoši sterliņu mārciņas un nulle pensu
+money	lv	gbp	2001	divas tūkstoši viena sterliņu mārciņa un nulle pensu
+money	lv	gbp	5000	pieci tūkstoši sterliņu mārciņas un nulle pensu
+money	lv	gbp	21000	divdesmit viena tūkstoši sterliņu mārciņas un nulle pensu
+money	lv	gbp	22000	divdesmit divas tūkstoši sterliņu mārciņas un nulle pensu
+money	lv	gbp	41000	četrdesmit viena tūkstoši sterliņu mārciņas un nulle pensu
+money	lv	gbp	42000	četrdesmit divas tūkstoši sterliņu mārciņas un nulle pensu
+money	lv	gbp	100000	simts tūkstoši sterliņu mārciņas un nulle pensu
+money	lv	gbp	1000000	viena miljons sterliņu mārciņas un nulle pensu
+money	lv	gbp	2000000	divas miljoni sterliņu mārciņas un nulle pensu
+money	lv	gbp	1000000000	viena miljards sterliņu mārciņas un nulle pensu
+money	lv	gbp	123.45	simts divdesmit trīs sterliņu mārciņas un četrdesmit pieci pensi
+money	lv	gbp	-1	mīnus viena sterliņu mārciņa un nulle pensu
+money	lv	gbp	-2	mīnus divas sterliņu mārciņas un nulle pensu
+money	lv	gbp	-41.5	mīnus četrdesmit viena sterliņu mārciņa un piecdesmit pensi
+money	lv	gbp	-1000	mīnus viena tūkstotis sterliņu mārciņas un nulle pensu
+money	lv	gbp	1.999	divas sterliņu mārciņas un nulle pensu
+money	lv	gbp	123.456	simts divdesmit trīs sterliņu mārciņas un četrdesmit seši pensi
+money	lv	gbp	1.005	viena sterliņu mārciņa un viens penss
 plain	en-GB	0	zero
 plain	en-GB	1	one
 plain	en-GB	2	two

--- a/src/Nut/Constants.cs
+++ b/src/Nut/Constants.cs
@@ -20,6 +20,7 @@
         public const string Portuguese = "pt";
         public const string German = "de";
         public const string Uzbek = "uz";
+        public const string Latvian = "lv";
     }
 
     public static class Culture
@@ -39,6 +40,7 @@
         public const string PortugueseBR = "pt-BR";
         public const string GermanDE = "de-DE";
         public const string Uzbek = "uz-UZ";
+        public const string Latvian = "lv-LV";
     }
 
     public static class Currency

--- a/src/Nut/Extentions.cs
+++ b/src/Nut/Extentions.cs
@@ -41,6 +41,8 @@ namespace Nut
                 { Culture.Bulgarian, BulgarianConverter.Instance },
                 { Language.Polish, PolishConverter.Instance },
                 { Culture.Polish, PolishConverter.Instance },
+                { Language.Latvian, LatvianConverter.Instance },
+                { Culture.Latvian, LatvianConverter.Instance },
                 { Language.Uzbek, UzbekConverter.Instance },
                 { Culture.Uzbek, UzbekConverter.Instance },
                 { Language.Amharic, AmharicConverter.Instance },

--- a/src/Nut/Nut.csproj
+++ b/src/Nut/Nut.csproj
@@ -8,7 +8,7 @@
     <Description>Number To Text Converter
 Money To Text Converter
 
-Supported Languages: English, Spanish, French, German, Turkish, Russian, Ukrainian, Bulgarian, Amharic, Polish, Belarussian, Portuguese, Uzbek.
+Supported Languages: English, Spanish, French, German, Turkish, Russian, Ukrainian, Bulgarian, Amharic, Polish, Belarussian, Portuguese, Uzbek, Latvian.
 
 Supported Currencies: EUR, USD, GBP, RUB, TRY, UAH, BGN, ETB, PLN, BYN, ARS, BRL, UZS.
 

--- a/src/Nut/TextConverters/LatvianConverter.cs
+++ b/src/Nut/TextConverters/LatvianConverter.cs
@@ -1,0 +1,213 @@
+using System;
+using System.Text;
+using Nut.Models;
+
+namespace Nut.TextConverters
+{
+  /// <summary>
+  /// Latvian. Numerals agree in gender with what they count — "viens eiro" but
+  /// "viena mārciņa" — and the unit name takes three forms rather than two: singular after
+  /// a count ending in one, plural otherwise, and the genitive plural after zero
+  /// ("nulle centu", not "nulle centi").
+  /// </summary>
+  public sealed class LatvianConverter : BaseConverter
+  {
+    private static readonly Lazy<LatvianConverter> Lazy = new Lazy<LatvianConverter>(() => new LatvianConverter());
+    public static LatvianConverter Instance => Lazy.Value;
+
+    public override string CultureName => Culture.Latvian;
+
+    protected override string NegativeSign => "mīnus";
+
+    public LatvianConverter()
+    {
+      Initialize();
+    }
+
+    // Set only on the short-lived per-conversion instance used for money.
+    private readonly bool _feminine;
+
+    private LatvianConverter(LatvianConverter template, bool feminine) : base(template)
+    {
+      _feminine = feminine;
+    }
+
+    protected override string ToText(long num, CurrencyModel currencyModel, bool isMainUnit)
+    {
+      var gender = isMainUnit ? currencyModel.Gender : currencyModel.SubUnitCurrency.Gender;
+      return new LatvianConverter(this, gender == GenderGroup.Feminine).ToText(num);
+    }
+
+    /// <summary>Only one and two inflect: viens/viena, divi/divas.</summary>
+    protected override void AppendUnits(long num, StringBuilder builder)
+    {
+      if (_feminine && (num == 1 || num == 2))
+        builder.AppendFormat("{0} ", NumberTexts[num][1]);
+      else
+        base.AppendUnits(num, builder);
+    }
+
+    protected override long Append(long num, long scale, StringBuilder builder)
+    {
+      if (num > scale - 1)
+      {
+        var baseScale = num / scale;
+        // The count is always spoken here: "viens tūkstotis", not a bare "tūkstotis".
+        AppendLessThanOneThousand(baseScale, builder);
+        builder.AppendFormat("{0} ", ScaleTexts[scale][baseScale == 1 ? 0 : 1]);
+        num = num - (baseScale * scale);
+      }
+      return num;
+    }
+
+    protected override long AppendHundreds(long num, StringBuilder builder)
+    {
+      if (num > 99)
+      {
+        var hundreds = num / 100;
+        // "simts" on its own, "divi simti" when multiplied.
+        if (hundreds == 1)
+        {
+          builder.AppendFormat("{0} ", NumberTexts[100][0]);
+        }
+        else
+        {
+          builder.AppendFormat("{0} {1} ", NumberTexts[hundreds][0], NumberTexts[100][1]);
+        }
+        num = num - (hundreds * 100);
+      }
+      return num;
+    }
+
+    /// <summary>
+    /// Singular after a count ending in one (but not eleven), genitive plural after zero,
+    /// plural otherwise.
+    /// </summary>
+    private static string Inflect(long num, string[] names)
+    {
+      if (num == 0) return names.Length > 2 ? names[2] : names[1];
+      if (num % 10 == 1 && num % 100 != 11) return names[0];
+      return names[1];
+    }
+
+    protected override string GetCurrencyText(long num, CurrencyModel currency)
+    {
+      return Inflect(num, currency.Names);
+    }
+
+    protected override string GetSubUnitCurrencyText(long num, CurrencyModel currency)
+    {
+      return Inflect(num, currency.SubUnitCurrency.Names);
+    }
+
+    protected override string GetUnitSeparator(CurrencyModel currency)
+    {
+      return " un ";
+    }
+
+    private void Initialize()
+    {
+      NumberTexts.Add(0, new[] { "nulle" });
+      NumberTexts.Add(1, new[] { "viens", "viena" });
+      NumberTexts.Add(2, new[] { "divi", "divas" });
+      NumberTexts.Add(3, new[] { "trīs" });
+      NumberTexts.Add(4, new[] { "četri" });
+      NumberTexts.Add(5, new[] { "pieci" });
+      NumberTexts.Add(6, new[] { "seši" });
+      NumberTexts.Add(7, new[] { "septiņi" });
+      NumberTexts.Add(8, new[] { "astoņi" });
+      NumberTexts.Add(9, new[] { "deviņi" });
+      NumberTexts.Add(10, new[] { "desmit" });
+      NumberTexts.Add(11, new[] { "vienpadsmit" });
+      NumberTexts.Add(12, new[] { "divpadsmit" });
+      NumberTexts.Add(13, new[] { "trīspadsmit" });
+      NumberTexts.Add(14, new[] { "četrpadsmit" });
+      NumberTexts.Add(15, new[] { "piecpadsmit" });
+      NumberTexts.Add(16, new[] { "sešpadsmit" });
+      NumberTexts.Add(17, new[] { "septiņpadsmit" });
+      NumberTexts.Add(18, new[] { "astoņpadsmit" });
+      NumberTexts.Add(19, new[] { "deviņpadsmit" });
+      NumberTexts.Add(20, new[] { "divdesmit" });
+      NumberTexts.Add(30, new[] { "trīsdesmit" });
+      NumberTexts.Add(40, new[] { "četrdesmit" });
+      NumberTexts.Add(50, new[] { "piecdesmit" });
+      NumberTexts.Add(60, new[] { "sešdesmit" });
+      NumberTexts.Add(70, new[] { "septiņdesmit" });
+      NumberTexts.Add(80, new[] { "astoņdesmit" });
+      NumberTexts.Add(90, new[] { "deviņdesmit" });
+      NumberTexts.Add(100, new[] { "simts", "simti" });
+
+      ScaleTexts.Add(1000000000, new[] { "miljards", "miljardi" });
+      ScaleTexts.Add(1000000, new[] { "miljons", "miljoni" });
+      ScaleTexts.Add(1000, new[] { "tūkstotis", "tūkstoši" });
+    }
+
+    protected override CurrencyModel GetCurrencyModel(string currency)
+    {
+      switch (currency)
+      {
+        case Currency.EUR:
+          return new CurrencyModel
+          {
+            Currency = currency,
+            Names = new[] { "eiro", "eiro", "eiro" },
+            Gender = GenderGroup.Masculine,
+            SubUnitCurrency = new BaseCurrencyModel
+            {
+              Gender = GenderGroup.Masculine,
+              Names = new[] { "cents", "centi", "centu" }
+            }
+          };
+        case Currency.GBP:
+          return new CurrencyModel
+          {
+            Currency = currency,
+            Names = new[] { "sterliņu mārciņa", "sterliņu mārciņas", "sterliņu mārciņu" },
+            Gender = GenderGroup.Feminine,
+            SubUnitCurrency = new BaseCurrencyModel
+            {
+              Gender = GenderGroup.Masculine,
+              Names = new[] { "penss", "pensi", "pensu" }
+            }
+          };
+        case Currency.USD:
+          return new CurrencyModel
+          {
+            Currency = currency,
+            Names = new[] { "ASV dolārs", "ASV dolāri", "ASV dolāru" },
+            Gender = GenderGroup.Masculine,
+            SubUnitCurrency = new BaseCurrencyModel
+            {
+              Gender = GenderGroup.Masculine,
+              Names = new[] { "cents", "centi", "centu" }
+            }
+          };
+        case Currency.RUB:
+          return new CurrencyModel
+          {
+            Currency = currency,
+            Names = new[] { "Krievijas rublis", "Krievijas rubļi", "Krievijas rubļu" },
+            Gender = GenderGroup.Masculine,
+            SubUnitCurrency = new BaseCurrencyModel
+            {
+              Gender = GenderGroup.Feminine,
+              Names = new[] { "kapeika", "kapeikas", "kapeiku" }
+            }
+          };
+        case Currency.PLN:
+          return new CurrencyModel
+          {
+            Currency = currency,
+            Names = new[] { "Polijas zlots", "Polijas zloti", "Polijas zlotu" },
+            Gender = GenderGroup.Masculine,
+            SubUnitCurrency = new BaseCurrencyModel
+            {
+              Gender = GenderGroup.Masculine,
+              Names = new[] { "grasis", "graši", "grašu" }
+            }
+          };
+      }
+      return null;
+    }
+  }
+}


### PR DESCRIPTION
From #24, the half I left out of the GBP PR. Additive.

I skipped it then because I could not verify Latvian inflection to the standard I had for Uzbek. The research you ran since settles it, so here it is.

## Two things the base converter does not handle

**Gender agreement.** `eiro` is masculine, `mārciņa` feminine:

```
1 EUR    viens eiro un nulle centu
1 GBP    viena sterliņu mārciņa un nulle pensu
21 GBP   divdesmit viena sterliņu mārciņa un nulle pensu
```

**Three unit forms, not two.** Singular after a count ending in one, plural otherwise, and the **genitive plural after zero**:

```
0 cents    nulle centu      <- not "nulle centi"
1 cent     viens cents
2 cents    divi centi
11 cents   vienpadsmit centi   <- eleven blocks the singular
21 cents   divdesmit viens cents
```

## Matches the reference line

The cheque example from the research renders character for character:

```
1234.56  viens tūkstotis divi simti trīsdesmit četri eiro un piecdesmit seši centi
```

## Review note

I wrote the sub-unit test expecting `21 cents` → `centi` and it failed. The code was right and my expectation wrong: a count ending in one takes the singular, 21 included. Corrected the test, not the code.

## Verification

- 575 tests. Snapshot extended to cover Latvian across all currencies.
- General behaviour applies without special-casing: `-41` → `mīnus četrdesmit viens`, `lv-LV` resolves, rounding and capitalisation work as elsewhere.

IlyashenkoA credited in the README for both GBP and Latvian.