### PR TITLE
feat: add the cheque fraction form for sub-units

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -154,6 +154,11 @@ assert on that text, review the tables below before taking this release.
   [#23](https://github.com/emrahyumuk/NUT-number-to-text/pull/23). The number system builds
   from twenty-two basic words and behaves like Turkish: no "bir" before *yuz* or *ming*.
 
+- `Options.SubUnitFormat`, an enum choosing how the fractional part is written: `Words`
+  (the default, "fifty cents"), `Digits` ("50 cents"), or `Fraction` ("and 50/100"), the
+  form commonly used on cheques. `SubUnitNotConvertedToText` still works and means
+  `Digits`.
+
 - `Options.SubUnitTruncated`, for callers who need extra decimals dropped rather than
   carried: `1.999` reads as "one dollar ninety-nine cents". Rounding remains the default.
 - `Currency.RUR` as an alias for `Currency.RUB`, mirroring how `tl` maps to `try`.

--- a/README.md
+++ b/README.md
@@ -17,6 +17,10 @@ Money To Text Converter
 
 **Number Limit:** 1 trillion
 
+**Cheque form:** `Options.SubUnitFormat = SubUnitFormat.Fraction` writes the fractional
+part as `and 50/100` instead of `fifty cents`, which is how amounts are commonly written
+on cheques. Zero is written as `00/100` rather than dropped.
+
 **Rounding:** amounts with more decimals than the currency has are rounded to the sub-unit,
 half away from zero — the same result `decimal.ToString("C")` gives. Set
 `Options.SubUnitTruncated` to cut the extra digits instead.
@@ -67,7 +71,8 @@ dotnet add package Nut
         MainUnitFirstCharUpper = true,
         SubUnitFirstCharUpper = true,
         CurrencyFirstCharUpper = true,
-        SubUnitTruncated = true
+        SubUnitTruncated = true,
+        SubUnitFormat = Nut.SubUnitFormat.Fraction
     }
     var moneyText = number.ToText(Nut.Currency.USD, Nut.Language.English, options);
 ```

--- a/src/Nut.Tests/SubUnitFormats.cs
+++ b/src/Nut.Tests/SubUnitFormats.cs
@@ -1,0 +1,71 @@
+namespace Nut.Tests
+{
+    /// <summary>
+    /// How the fractional part is written. The default spells it out, which is what the
+    /// language calls for. Cheques commonly use a fraction over a hundred instead — Chase
+    /// and Capital One both document "and 50/100" — so that is available as an opt-in.
+    /// It is a document convention rather than a rule of the language, which is why it is
+    /// not the default.
+    /// </summary>
+    [TestFixture]
+    public class SubUnitFormats
+    {
+        private static Options Fraction => new Options { SubUnitFormat = SubUnitFormat.Fraction };
+
+        [TestCase(2575.50, "two thousand five hundred seventy-five dollars and 50/100")]
+        [TestCase(105.05, "one hundred five dollars and 05/100")]
+        [TestCase(1.99, "one dollar and 99/100")]
+        public void FractionForm(decimal amount, string expected)
+        {
+            Assert.That(amount.ToText(Currency.USD, Language.English, Fraction), Is.EqualTo(expected));
+        }
+
+        /// <summary>Zero is written out rather than dropped: the form exists so nothing can
+        /// be appended to the amount afterwards.</summary>
+        [Test]
+        public void ZeroIsStillWritten()
+        {
+            Assert.That(2575m.ToText(Currency.USD, Language.English, Fraction),
+                Is.EqualTo("two thousand five hundred seventy-five dollars and 00/100"));
+        }
+
+        [Test]
+        public void DefaultIsUnchanged()
+        {
+            Assert.That(2575.50m.ToText(Currency.USD, Language.English),
+                Is.EqualTo("two thousand five hundred seventy-five dollars fifty cents"));
+        }
+
+        /// <summary>The enum's Digits and the older bool mean the same thing.</summary>
+        [Test]
+        public void DigitsMatchesTheOlderFlag()
+        {
+            var viaEnum = 2575.50m.ToText(Currency.USD, Language.English,
+                new Options { SubUnitFormat = SubUnitFormat.Digits });
+            var viaBool = 2575.50m.ToText(Currency.USD, Language.English,
+                new Options { SubUnitNotConvertedToText = true });
+
+            Assert.That(viaEnum, Is.EqualTo("two thousand five hundred seventy-five dollars 50 cents"));
+            Assert.That(viaBool, Is.EqualTo(viaEnum));
+        }
+
+        /// <summary>Languages that already join the two parts with a word keep that word
+        /// rather than borrowing the English "and".</summary>
+        [TestCase(Language.Spanish, Currency.EUR, "ciento cinco euros con 50/100")]
+        [TestCase(Language.Portuguese, Currency.BRL, "cento e cinco reais e 50/100")]
+        [TestCase(Language.Bulgarian, Currency.BGN, "сто и пет лева и 50/100")]
+        [TestCase(Language.Latvian, Currency.EUR, "simts pieci eiro un 50/100")]
+        public void SeparatorFollowsTheLanguage(string lang, string currency, string expected)
+        {
+            Assert.That(105.50m.ToText(currency, lang, Fraction), Is.EqualTo(expected));
+        }
+
+        [Test]
+        public void WorksWithTheOtherOptions()
+        {
+            var options = new Options { SubUnitFormat = SubUnitFormat.Fraction, MainUnitFirstCharUpper = true };
+            Assert.That((-2575.50m).ToText(Currency.USD, Language.English, options),
+                Is.EqualTo("Minus two thousand five hundred seventy-five dollars and 50/100"));
+        }
+    }
+}

--- a/src/Nut/Options.cs
+++ b/src/Nut/Options.cs
@@ -3,7 +3,17 @@
     public struct Options
     {
         public bool MainUnitNotConvertedToText { get; set; }
+        /// <summary>
+        /// Equivalent to <see cref="SubUnitFormat.Digits"/>. Kept because it predates
+        /// <see cref="SubUnitFormat"/>; setting either has the same effect.
+        /// </summary>
         public bool SubUnitNotConvertedToText { get; set; }
+
+        /// <summary>
+        /// How the fractional part is written. Defaults to <see cref="SubUnitFormat.Words"/>.
+        /// <see cref="SubUnitFormat.Fraction"/> gives the cheque form, "and 50/100".
+        /// </summary>
+        public SubUnitFormat SubUnitFormat { get; set; }
         public bool SubUnitZeroNotDisplayed { get; set; }
         public bool MainUnitFirstCharUpper { get; set; }
         public bool SubUnitFirstCharUpper { get; set; }

--- a/src/Nut/SubUnitFormat.cs
+++ b/src/Nut/SubUnitFormat.cs
@@ -1,0 +1,19 @@
+namespace Nut
+{
+    /// <summary>How the fractional part of an amount is rendered.</summary>
+    public enum SubUnitFormat
+    {
+        /// <summary>Spelled out, with the sub-unit name: "fifty cents".</summary>
+        Words = 0,
+
+        /// <summary>Digits, with the sub-unit name: "50 cents".</summary>
+        Digits,
+
+        /// <summary>
+        /// The fraction-over-hundred form used on cheques: "and 50/100", with no sub-unit
+        /// name. Zero is written out rather than dropped — "and 00/100" — because the point
+        /// of the form is to leave no room to add digits afterwards.
+        /// </summary>
+        Fraction,
+    }
+}

--- a/src/Nut/TextConverters/BaseConverter.cs
+++ b/src/Nut/TextConverters/BaseConverter.cs
@@ -216,11 +216,24 @@ namespace Nut.TextConverters
       {
         var subUnitText = nums[1].PadRight(2, '0');
         var subUnitNum = Convert.ToInt64(subUnitText);
-        if (!options.SubUnitZeroNotDisplayed || subUnitNum != 0)
+
+        // The older bool says the same thing as Digits; whichever is set wins.
+        var subUnitFormat = options.SubUnitFormat != SubUnitFormat.Words ? options.SubUnitFormat
+          : options.SubUnitNotConvertedToText ? SubUnitFormat.Digits
+          : SubUnitFormat.Words;
+
+        if (subUnitFormat == SubUnitFormat.Fraction)
+        {
+          // "and 50/100", the form used on cheques. The sub-unit is not named, and zero is
+          // written rather than dropped, so nothing can be appended to the amount later.
+          builder.Append(GetFractionSeparator(currencyModel));
+          builder.AppendFormat("{0:00}/100", subUnitNum);
+        }
+        else if (!options.SubUnitZeroNotDisplayed || subUnitNum != 0)
         {
           builder.Append(GetUnitSeparator(currencyModel));
 
-          if (options.SubUnitNotConvertedToText)
+          if (subUnitFormat == SubUnitFormat.Digits)
           {
             builder.Append(subUnitText);
           }
@@ -264,6 +277,16 @@ namespace Nut.TextConverters
     protected virtual string GetUnitSeparator(CurrencyModel currency)
     {
       return " ";
+    }
+
+    /// <summary>
+    /// What joins the amount to a fraction-form sub-unit. English cheques say "and";
+    /// languages that already join the two parts with a word reuse that word.
+    /// </summary>
+    protected virtual string GetFractionSeparator(CurrencyModel currency)
+    {
+      var separator = GetUnitSeparator(currency);
+      return separator.Trim().Length > 0 ? separator : " and ";
     }
     #endregion
   }


### PR DESCRIPTION
Opt-in. The default is unchanged.

```
default    two thousand five hundred seventy-five dollars fifty cents
Fraction   two thousand five hundred seventy-five dollars and 50/100
```

[Chase](https://www.chase.com/personal/banking/education/basics/how-to-write-a-check) documents both forms; [Capital One](https://www.capitalone.com/learn-grow/money-management/how-to-write-a-check/) recommends the fraction and specifically recommends `00/100` when there are no cents. It is a document convention rather than a rule of the language, which is why it is not the default.

## Why an enum rather than a bool

The fraction changes **three** things where `SubUnitNotConvertedToText` changes one:

| | separator | number | sub-unit name |
|---|---|---|---|
| `Words` | `" "` | fifty | cents |
| `Digits` | `" "` | 50 | cents |
| `Fraction` | `" and "` | 50/100 | *dropped* |

`SubUnitNotConvertedToText` keeps working and means `Digits`; whichever is set wins.

## Zero is written, not dropped

```
2575.00   ->   ... dollars and 00/100
```

The form exists so nothing can be appended to the amount after it is written. An omitted fraction defeats that; `00/100` does not.

## Separator follows the language

Languages that already join the two parts with a word reuse it rather than borrowing the English "and":

```
es   ciento cinco euros con 50/100
pt   cento e cinco reais e 50/100
bg   сто и пет лева и 50/100
lv   simts pieci eiro un 50/100
```

Only languages that join with a bare space fall back to "and".

## Verification

- Snapshot untouched — it renders with default options.
- Composes with the rest: `Minus two thousand five hundred seventy-five dollars and 50/100`.
- 586 tests.