### PR TITLE
feat: fail loudly on an unsupported language or currency

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -123,6 +123,15 @@ assert on that text, review the tables below before taking this release.
 
 ### Changed
 
+- **An unsupported language or currency now throws `NotSupportedException`** instead of
+  returning an empty string. This library writes amounts onto invoices and cheques, where
+  a blank in the amount field is worse than a failed call: nothing surfaces it until the
+  document has already gone out. The message names what was asked for, and for a language
+  it lists what is accepted.
+
+  If you relied on the empty string, catch `NotSupportedException` or check
+  `Extentions.SupportedLanguages` first.
+
 - **Numbers past the supported range throw `ArgumentOutOfRangeException`** instead of a bare
   `Exception`, so callers can catch it selectively. The message states the range.
 
@@ -153,6 +162,8 @@ assert on that text, review the tables below before taking this release.
 - **Uzbek (Latin script)** and the Uzbek som (`UZS`), from
   [#23](https://github.com/emrahyumuk/NUT-number-to-text/pull/23). The number system builds
   from twenty-two basic words and behaves like Turkish: no "bir" before *yuz* or *ming*.
+
+- `Extentions.SupportedLanguages`, listing every language and culture string accepted.
 
 - `Options.SubUnitFormat`, an enum choosing how the fractional part is written: `Words`
   (the default, "fifty cents"), `Digits` ("50 cents"), or `Fraction` ("and 50/100"), the

--- a/README.md
+++ b/README.md
@@ -17,6 +17,10 @@ Money To Text Converter
 
 **Number Limit:** 1 trillion
 
+**Unsupported input:** asking for a language or currency that is not supported throws
+`NotSupportedException` rather than returning an empty string — a blank amount field is
+harder to notice than an exception. `Extentions.SupportedLanguages` lists what is accepted.
+
 **Cheque form:** `Options.SubUnitFormat = SubUnitFormat.Fraction` writes the fractional
 part as `and 50/100` instead of `fifty cents`, which is how amounts are commonly written
 on cheques. Zero is written as `00/100` rather than dropped.

--- a/src/Nut.Tests/LanguageResolution.cs
+++ b/src/Nut.Tests/LanguageResolution.cs
@@ -1,4 +1,5 @@
-﻿namespace Nut.Tests
+﻿using System;
+namespace Nut.Tests
 {
     /// <summary>
     /// Which language string resolves to which converter. The int overloads used to
@@ -67,22 +68,40 @@
             Assert.That(41m.ToText(currency, Language.English), Is.EqualTo(expected));
         }
 
-        /// <summary>Unknown input still returns empty rather than throwing.</summary>
+        /// <summary>An unsupported language fails loudly rather than returning "".</summary>
         [TestCase("xx")]
         [TestCase("")]
         [TestCase("zz-ZZ")]
         [TestCase(null)]
-        public void UnknownLanguageIsEmpty(string lang)
+        public void UnknownLanguageThrows(string lang)
         {
-            Assert.That(101.ToText(lang), Is.Empty);
-            Assert.That(41m.ToText(Currency.USD, lang), Is.Empty);
+            Assert.That(() => 101.ToText(lang), Throws.InstanceOf<NotSupportedException>());
+            Assert.That(() => 41m.ToText(Currency.USD, lang), Throws.InstanceOf<NotSupportedException>());
         }
 
         [Test]
-        public void UnknownCurrencyIsEmpty()
+        public void UnknownCurrencyThrows()
         {
-            Assert.That(41m.ToText("zzz", Language.English), Is.Empty);
-            Assert.That(41m.ToText(null, Language.English), Is.Empty);
+            Assert.That(() => 41m.ToText("zzz", Language.English), Throws.InstanceOf<NotSupportedException>());
+            Assert.That(() => 41m.ToText(null, Language.English), Throws.InstanceOf<NotSupportedException>());
+        }
+
+        /// <summary>The message has to say what went wrong and what would work.</summary>
+        [Test]
+        public void TheMessageNamesTheProblemAndTheAlternatives()
+        {
+            var lang = Assert.Throws<NotSupportedException>(() => 101.ToText("xx"));
+            Assert.That(lang.Message, Does.Contain("xx").And.Contain("en").And.Contain("tr"));
+
+            var currency = Assert.Throws<NotSupportedException>(
+                () => 1m.ToText(Currency.ARS, Language.Amharic));
+            Assert.That(currency.Message, Does.Contain("ars").And.Contain("am-ET"));
+        }
+
+        [Test]
+        public void SupportedLanguagesIsDiscoverable()
+        {
+            Assert.That(Extentions.SupportedLanguages, Contains.Item("en").And.Contains("en-GB").And.Contains("lv"));
         }
     }
 }

--- a/src/Nut.Tests/behaviour-snapshot.tsv
+++ b/src/Nut.Tests/behaviour-snapshot.tsv
@@ -6298,162 +6298,162 @@ money	am	byn	-1000	ሲቀነስ አንድ ሺህ የቤላሩስ ሩብል ከ �
 money	am	byn	1.999	ሁለት የቤላሩስ ሩብል ከ ዜሮ ሳንቲም
 money	am	byn	123.456	አንድ መቶ ሀያ ሶስት የቤላሩስ ሩብል ከ አርባ ስድስት ሳንቲም
 money	am	byn	1.005	አንድ የቤላሩስ ሩብል ከ አንድ ሳንቲም
-money	am	ars	0	
-money	am	ars	0.01	
-money	am	ars	0.02	
-money	am	ars	1	
-money	am	ars	1.01	
-money	am	ars	1.02	
-money	am	ars	2	
-money	am	ars	2.02	
-money	am	ars	3	
-money	am	ars	5	
-money	am	ars	11	
-money	am	ars	21	
-money	am	ars	22	
-money	am	ars	42	
-money	am	ars	100	
-money	am	ars	101	
-money	am	ars	121	
-money	am	ars	999	
-money	am	ars	1000	
-money	am	ars	1001	
-money	am	ars	2000	
-money	am	ars	2001	
-money	am	ars	5000	
-money	am	ars	21000	
-money	am	ars	22000	
-money	am	ars	41000	
-money	am	ars	42000	
-money	am	ars	100000	
-money	am	ars	1000000	
-money	am	ars	2000000	
-money	am	ars	1000000000	
-money	am	ars	123.45	
-money	am	ars	-1	
-money	am	ars	-2	
-money	am	ars	-41.5	
-money	am	ars	-1000	
-money	am	ars	1.999	
-money	am	ars	123.456	
-money	am	ars	1.005	
-money	am	brl	0	
-money	am	brl	0.01	
-money	am	brl	0.02	
-money	am	brl	1	
-money	am	brl	1.01	
-money	am	brl	1.02	
-money	am	brl	2	
-money	am	brl	2.02	
-money	am	brl	3	
-money	am	brl	5	
-money	am	brl	11	
-money	am	brl	21	
-money	am	brl	22	
-money	am	brl	42	
-money	am	brl	100	
-money	am	brl	101	
-money	am	brl	121	
-money	am	brl	999	
-money	am	brl	1000	
-money	am	brl	1001	
-money	am	brl	2000	
-money	am	brl	2001	
-money	am	brl	5000	
-money	am	brl	21000	
-money	am	brl	22000	
-money	am	brl	41000	
-money	am	brl	42000	
-money	am	brl	100000	
-money	am	brl	1000000	
-money	am	brl	2000000	
-money	am	brl	1000000000	
-money	am	brl	123.45	
-money	am	brl	-1	
-money	am	brl	-2	
-money	am	brl	-41.5	
-money	am	brl	-1000	
-money	am	brl	1.999	
-money	am	brl	123.456	
-money	am	brl	1.005	
-money	am	uzs	0	
-money	am	uzs	0.01	
-money	am	uzs	0.02	
-money	am	uzs	1	
-money	am	uzs	1.01	
-money	am	uzs	1.02	
-money	am	uzs	2	
-money	am	uzs	2.02	
-money	am	uzs	3	
-money	am	uzs	5	
-money	am	uzs	11	
-money	am	uzs	21	
-money	am	uzs	22	
-money	am	uzs	42	
-money	am	uzs	100	
-money	am	uzs	101	
-money	am	uzs	121	
-money	am	uzs	999	
-money	am	uzs	1000	
-money	am	uzs	1001	
-money	am	uzs	2000	
-money	am	uzs	2001	
-money	am	uzs	5000	
-money	am	uzs	21000	
-money	am	uzs	22000	
-money	am	uzs	41000	
-money	am	uzs	42000	
-money	am	uzs	100000	
-money	am	uzs	1000000	
-money	am	uzs	2000000	
-money	am	uzs	1000000000	
-money	am	uzs	123.45	
-money	am	uzs	-1	
-money	am	uzs	-2	
-money	am	uzs	-41.5	
-money	am	uzs	-1000	
-money	am	uzs	1.999	
-money	am	uzs	123.456	
-money	am	uzs	1.005	
-money	am	gbp	0	
-money	am	gbp	0.01	
-money	am	gbp	0.02	
-money	am	gbp	1	
-money	am	gbp	1.01	
-money	am	gbp	1.02	
-money	am	gbp	2	
-money	am	gbp	2.02	
-money	am	gbp	3	
-money	am	gbp	5	
-money	am	gbp	11	
-money	am	gbp	21	
-money	am	gbp	22	
-money	am	gbp	42	
-money	am	gbp	100	
-money	am	gbp	101	
-money	am	gbp	121	
-money	am	gbp	999	
-money	am	gbp	1000	
-money	am	gbp	1001	
-money	am	gbp	2000	
-money	am	gbp	2001	
-money	am	gbp	5000	
-money	am	gbp	21000	
-money	am	gbp	22000	
-money	am	gbp	41000	
-money	am	gbp	42000	
-money	am	gbp	100000	
-money	am	gbp	1000000	
-money	am	gbp	2000000	
-money	am	gbp	1000000000	
-money	am	gbp	123.45	
-money	am	gbp	-1	
-money	am	gbp	-2	
-money	am	gbp	-41.5	
-money	am	gbp	-1000	
-money	am	gbp	1.999	
-money	am	gbp	123.456	
-money	am	gbp	1.005	
+money	am	ars	0	EX:NotSupportedException
+money	am	ars	0.01	EX:NotSupportedException
+money	am	ars	0.02	EX:NotSupportedException
+money	am	ars	1	EX:NotSupportedException
+money	am	ars	1.01	EX:NotSupportedException
+money	am	ars	1.02	EX:NotSupportedException
+money	am	ars	2	EX:NotSupportedException
+money	am	ars	2.02	EX:NotSupportedException
+money	am	ars	3	EX:NotSupportedException
+money	am	ars	5	EX:NotSupportedException
+money	am	ars	11	EX:NotSupportedException
+money	am	ars	21	EX:NotSupportedException
+money	am	ars	22	EX:NotSupportedException
+money	am	ars	42	EX:NotSupportedException
+money	am	ars	100	EX:NotSupportedException
+money	am	ars	101	EX:NotSupportedException
+money	am	ars	121	EX:NotSupportedException
+money	am	ars	999	EX:NotSupportedException
+money	am	ars	1000	EX:NotSupportedException
+money	am	ars	1001	EX:NotSupportedException
+money	am	ars	2000	EX:NotSupportedException
+money	am	ars	2001	EX:NotSupportedException
+money	am	ars	5000	EX:NotSupportedException
+money	am	ars	21000	EX:NotSupportedException
+money	am	ars	22000	EX:NotSupportedException
+money	am	ars	41000	EX:NotSupportedException
+money	am	ars	42000	EX:NotSupportedException
+money	am	ars	100000	EX:NotSupportedException
+money	am	ars	1000000	EX:NotSupportedException
+money	am	ars	2000000	EX:NotSupportedException
+money	am	ars	1000000000	EX:NotSupportedException
+money	am	ars	123.45	EX:NotSupportedException
+money	am	ars	-1	EX:NotSupportedException
+money	am	ars	-2	EX:NotSupportedException
+money	am	ars	-41.5	EX:NotSupportedException
+money	am	ars	-1000	EX:NotSupportedException
+money	am	ars	1.999	EX:NotSupportedException
+money	am	ars	123.456	EX:NotSupportedException
+money	am	ars	1.005	EX:NotSupportedException
+money	am	brl	0	EX:NotSupportedException
+money	am	brl	0.01	EX:NotSupportedException
+money	am	brl	0.02	EX:NotSupportedException
+money	am	brl	1	EX:NotSupportedException
+money	am	brl	1.01	EX:NotSupportedException
+money	am	brl	1.02	EX:NotSupportedException
+money	am	brl	2	EX:NotSupportedException
+money	am	brl	2.02	EX:NotSupportedException
+money	am	brl	3	EX:NotSupportedException
+money	am	brl	5	EX:NotSupportedException
+money	am	brl	11	EX:NotSupportedException
+money	am	brl	21	EX:NotSupportedException
+money	am	brl	22	EX:NotSupportedException
+money	am	brl	42	EX:NotSupportedException
+money	am	brl	100	EX:NotSupportedException
+money	am	brl	101	EX:NotSupportedException
+money	am	brl	121	EX:NotSupportedException
+money	am	brl	999	EX:NotSupportedException
+money	am	brl	1000	EX:NotSupportedException
+money	am	brl	1001	EX:NotSupportedException
+money	am	brl	2000	EX:NotSupportedException
+money	am	brl	2001	EX:NotSupportedException
+money	am	brl	5000	EX:NotSupportedException
+money	am	brl	21000	EX:NotSupportedException
+money	am	brl	22000	EX:NotSupportedException
+money	am	brl	41000	EX:NotSupportedException
+money	am	brl	42000	EX:NotSupportedException
+money	am	brl	100000	EX:NotSupportedException
+money	am	brl	1000000	EX:NotSupportedException
+money	am	brl	2000000	EX:NotSupportedException
+money	am	brl	1000000000	EX:NotSupportedException
+money	am	brl	123.45	EX:NotSupportedException
+money	am	brl	-1	EX:NotSupportedException
+money	am	brl	-2	EX:NotSupportedException
+money	am	brl	-41.5	EX:NotSupportedException
+money	am	brl	-1000	EX:NotSupportedException
+money	am	brl	1.999	EX:NotSupportedException
+money	am	brl	123.456	EX:NotSupportedException
+money	am	brl	1.005	EX:NotSupportedException
+money	am	uzs	0	EX:NotSupportedException
+money	am	uzs	0.01	EX:NotSupportedException
+money	am	uzs	0.02	EX:NotSupportedException
+money	am	uzs	1	EX:NotSupportedException
+money	am	uzs	1.01	EX:NotSupportedException
+money	am	uzs	1.02	EX:NotSupportedException
+money	am	uzs	2	EX:NotSupportedException
+money	am	uzs	2.02	EX:NotSupportedException
+money	am	uzs	3	EX:NotSupportedException
+money	am	uzs	5	EX:NotSupportedException
+money	am	uzs	11	EX:NotSupportedException
+money	am	uzs	21	EX:NotSupportedException
+money	am	uzs	22	EX:NotSupportedException
+money	am	uzs	42	EX:NotSupportedException
+money	am	uzs	100	EX:NotSupportedException
+money	am	uzs	101	EX:NotSupportedException
+money	am	uzs	121	EX:NotSupportedException
+money	am	uzs	999	EX:NotSupportedException
+money	am	uzs	1000	EX:NotSupportedException
+money	am	uzs	1001	EX:NotSupportedException
+money	am	uzs	2000	EX:NotSupportedException
+money	am	uzs	2001	EX:NotSupportedException
+money	am	uzs	5000	EX:NotSupportedException
+money	am	uzs	21000	EX:NotSupportedException
+money	am	uzs	22000	EX:NotSupportedException
+money	am	uzs	41000	EX:NotSupportedException
+money	am	uzs	42000	EX:NotSupportedException
+money	am	uzs	100000	EX:NotSupportedException
+money	am	uzs	1000000	EX:NotSupportedException
+money	am	uzs	2000000	EX:NotSupportedException
+money	am	uzs	1000000000	EX:NotSupportedException
+money	am	uzs	123.45	EX:NotSupportedException
+money	am	uzs	-1	EX:NotSupportedException
+money	am	uzs	-2	EX:NotSupportedException
+money	am	uzs	-41.5	EX:NotSupportedException
+money	am	uzs	-1000	EX:NotSupportedException
+money	am	uzs	1.999	EX:NotSupportedException
+money	am	uzs	123.456	EX:NotSupportedException
+money	am	uzs	1.005	EX:NotSupportedException
+money	am	gbp	0	EX:NotSupportedException
+money	am	gbp	0.01	EX:NotSupportedException
+money	am	gbp	0.02	EX:NotSupportedException
+money	am	gbp	1	EX:NotSupportedException
+money	am	gbp	1.01	EX:NotSupportedException
+money	am	gbp	1.02	EX:NotSupportedException
+money	am	gbp	2	EX:NotSupportedException
+money	am	gbp	2.02	EX:NotSupportedException
+money	am	gbp	3	EX:NotSupportedException
+money	am	gbp	5	EX:NotSupportedException
+money	am	gbp	11	EX:NotSupportedException
+money	am	gbp	21	EX:NotSupportedException
+money	am	gbp	22	EX:NotSupportedException
+money	am	gbp	42	EX:NotSupportedException
+money	am	gbp	100	EX:NotSupportedException
+money	am	gbp	101	EX:NotSupportedException
+money	am	gbp	121	EX:NotSupportedException
+money	am	gbp	999	EX:NotSupportedException
+money	am	gbp	1000	EX:NotSupportedException
+money	am	gbp	1001	EX:NotSupportedException
+money	am	gbp	2000	EX:NotSupportedException
+money	am	gbp	2001	EX:NotSupportedException
+money	am	gbp	5000	EX:NotSupportedException
+money	am	gbp	21000	EX:NotSupportedException
+money	am	gbp	22000	EX:NotSupportedException
+money	am	gbp	41000	EX:NotSupportedException
+money	am	gbp	42000	EX:NotSupportedException
+money	am	gbp	100000	EX:NotSupportedException
+money	am	gbp	1000000	EX:NotSupportedException
+money	am	gbp	2000000	EX:NotSupportedException
+money	am	gbp	1000000000	EX:NotSupportedException
+money	am	gbp	123.45	EX:NotSupportedException
+money	am	gbp	-1	EX:NotSupportedException
+money	am	gbp	-2	EX:NotSupportedException
+money	am	gbp	-41.5	EX:NotSupportedException
+money	am	gbp	-1000	EX:NotSupportedException
+money	am	gbp	1.999	EX:NotSupportedException
+money	am	gbp	123.456	EX:NotSupportedException
+money	am	gbp	1.005	EX:NotSupportedException
 plain	uz	0	nol
 plain	uz	1	bir
 plain	uz	2	ikki
@@ -7140,162 +7140,162 @@ money	lv	rub	-1000	mīnus viens tūkstotis Krievijas rubļi un nulle kapeiku
 money	lv	rub	1.999	divi Krievijas rubļi un nulle kapeiku
 money	lv	rub	123.456	simts divdesmit trīs Krievijas rubļi un četrdesmit seši kapeikas
 money	lv	rub	1.005	viens Krievijas rublis un viena kapeika
-money	lv	try	0	
-money	lv	try	0.01	
-money	lv	try	0.02	
-money	lv	try	1	
-money	lv	try	1.01	
-money	lv	try	1.02	
-money	lv	try	2	
-money	lv	try	2.02	
-money	lv	try	3	
-money	lv	try	5	
-money	lv	try	11	
-money	lv	try	21	
-money	lv	try	22	
-money	lv	try	42	
-money	lv	try	100	
-money	lv	try	101	
-money	lv	try	121	
-money	lv	try	999	
-money	lv	try	1000	
-money	lv	try	1001	
-money	lv	try	2000	
-money	lv	try	2001	
-money	lv	try	5000	
-money	lv	try	21000	
-money	lv	try	22000	
-money	lv	try	41000	
-money	lv	try	42000	
-money	lv	try	100000	
-money	lv	try	1000000	
-money	lv	try	2000000	
-money	lv	try	1000000000	
-money	lv	try	123.45	
-money	lv	try	-1	
-money	lv	try	-2	
-money	lv	try	-41.5	
-money	lv	try	-1000	
-money	lv	try	1.999	
-money	lv	try	123.456	
-money	lv	try	1.005	
-money	lv	uah	0	
-money	lv	uah	0.01	
-money	lv	uah	0.02	
-money	lv	uah	1	
-money	lv	uah	1.01	
-money	lv	uah	1.02	
-money	lv	uah	2	
-money	lv	uah	2.02	
-money	lv	uah	3	
-money	lv	uah	5	
-money	lv	uah	11	
-money	lv	uah	21	
-money	lv	uah	22	
-money	lv	uah	42	
-money	lv	uah	100	
-money	lv	uah	101	
-money	lv	uah	121	
-money	lv	uah	999	
-money	lv	uah	1000	
-money	lv	uah	1001	
-money	lv	uah	2000	
-money	lv	uah	2001	
-money	lv	uah	5000	
-money	lv	uah	21000	
-money	lv	uah	22000	
-money	lv	uah	41000	
-money	lv	uah	42000	
-money	lv	uah	100000	
-money	lv	uah	1000000	
-money	lv	uah	2000000	
-money	lv	uah	1000000000	
-money	lv	uah	123.45	
-money	lv	uah	-1	
-money	lv	uah	-2	
-money	lv	uah	-41.5	
-money	lv	uah	-1000	
-money	lv	uah	1.999	
-money	lv	uah	123.456	
-money	lv	uah	1.005	
-money	lv	bgn	0	
-money	lv	bgn	0.01	
-money	lv	bgn	0.02	
-money	lv	bgn	1	
-money	lv	bgn	1.01	
-money	lv	bgn	1.02	
-money	lv	bgn	2	
-money	lv	bgn	2.02	
-money	lv	bgn	3	
-money	lv	bgn	5	
-money	lv	bgn	11	
-money	lv	bgn	21	
-money	lv	bgn	22	
-money	lv	bgn	42	
-money	lv	bgn	100	
-money	lv	bgn	101	
-money	lv	bgn	121	
-money	lv	bgn	999	
-money	lv	bgn	1000	
-money	lv	bgn	1001	
-money	lv	bgn	2000	
-money	lv	bgn	2001	
-money	lv	bgn	5000	
-money	lv	bgn	21000	
-money	lv	bgn	22000	
-money	lv	bgn	41000	
-money	lv	bgn	42000	
-money	lv	bgn	100000	
-money	lv	bgn	1000000	
-money	lv	bgn	2000000	
-money	lv	bgn	1000000000	
-money	lv	bgn	123.45	
-money	lv	bgn	-1	
-money	lv	bgn	-2	
-money	lv	bgn	-41.5	
-money	lv	bgn	-1000	
-money	lv	bgn	1.999	
-money	lv	bgn	123.456	
-money	lv	bgn	1.005	
-money	lv	etb	0	
-money	lv	etb	0.01	
-money	lv	etb	0.02	
-money	lv	etb	1	
-money	lv	etb	1.01	
-money	lv	etb	1.02	
-money	lv	etb	2	
-money	lv	etb	2.02	
-money	lv	etb	3	
-money	lv	etb	5	
-money	lv	etb	11	
-money	lv	etb	21	
-money	lv	etb	22	
-money	lv	etb	42	
-money	lv	etb	100	
-money	lv	etb	101	
-money	lv	etb	121	
-money	lv	etb	999	
-money	lv	etb	1000	
-money	lv	etb	1001	
-money	lv	etb	2000	
-money	lv	etb	2001	
-money	lv	etb	5000	
-money	lv	etb	21000	
-money	lv	etb	22000	
-money	lv	etb	41000	
-money	lv	etb	42000	
-money	lv	etb	100000	
-money	lv	etb	1000000	
-money	lv	etb	2000000	
-money	lv	etb	1000000000	
-money	lv	etb	123.45	
-money	lv	etb	-1	
-money	lv	etb	-2	
-money	lv	etb	-41.5	
-money	lv	etb	-1000	
-money	lv	etb	1.999	
-money	lv	etb	123.456	
-money	lv	etb	1.005	
+money	lv	try	0	EX:NotSupportedException
+money	lv	try	0.01	EX:NotSupportedException
+money	lv	try	0.02	EX:NotSupportedException
+money	lv	try	1	EX:NotSupportedException
+money	lv	try	1.01	EX:NotSupportedException
+money	lv	try	1.02	EX:NotSupportedException
+money	lv	try	2	EX:NotSupportedException
+money	lv	try	2.02	EX:NotSupportedException
+money	lv	try	3	EX:NotSupportedException
+money	lv	try	5	EX:NotSupportedException
+money	lv	try	11	EX:NotSupportedException
+money	lv	try	21	EX:NotSupportedException
+money	lv	try	22	EX:NotSupportedException
+money	lv	try	42	EX:NotSupportedException
+money	lv	try	100	EX:NotSupportedException
+money	lv	try	101	EX:NotSupportedException
+money	lv	try	121	EX:NotSupportedException
+money	lv	try	999	EX:NotSupportedException
+money	lv	try	1000	EX:NotSupportedException
+money	lv	try	1001	EX:NotSupportedException
+money	lv	try	2000	EX:NotSupportedException
+money	lv	try	2001	EX:NotSupportedException
+money	lv	try	5000	EX:NotSupportedException
+money	lv	try	21000	EX:NotSupportedException
+money	lv	try	22000	EX:NotSupportedException
+money	lv	try	41000	EX:NotSupportedException
+money	lv	try	42000	EX:NotSupportedException
+money	lv	try	100000	EX:NotSupportedException
+money	lv	try	1000000	EX:NotSupportedException
+money	lv	try	2000000	EX:NotSupportedException
+money	lv	try	1000000000	EX:NotSupportedException
+money	lv	try	123.45	EX:NotSupportedException
+money	lv	try	-1	EX:NotSupportedException
+money	lv	try	-2	EX:NotSupportedException
+money	lv	try	-41.5	EX:NotSupportedException
+money	lv	try	-1000	EX:NotSupportedException
+money	lv	try	1.999	EX:NotSupportedException
+money	lv	try	123.456	EX:NotSupportedException
+money	lv	try	1.005	EX:NotSupportedException
+money	lv	uah	0	EX:NotSupportedException
+money	lv	uah	0.01	EX:NotSupportedException
+money	lv	uah	0.02	EX:NotSupportedException
+money	lv	uah	1	EX:NotSupportedException
+money	lv	uah	1.01	EX:NotSupportedException
+money	lv	uah	1.02	EX:NotSupportedException
+money	lv	uah	2	EX:NotSupportedException
+money	lv	uah	2.02	EX:NotSupportedException
+money	lv	uah	3	EX:NotSupportedException
+money	lv	uah	5	EX:NotSupportedException
+money	lv	uah	11	EX:NotSupportedException
+money	lv	uah	21	EX:NotSupportedException
+money	lv	uah	22	EX:NotSupportedException
+money	lv	uah	42	EX:NotSupportedException
+money	lv	uah	100	EX:NotSupportedException
+money	lv	uah	101	EX:NotSupportedException
+money	lv	uah	121	EX:NotSupportedException
+money	lv	uah	999	EX:NotSupportedException
+money	lv	uah	1000	EX:NotSupportedException
+money	lv	uah	1001	EX:NotSupportedException
+money	lv	uah	2000	EX:NotSupportedException
+money	lv	uah	2001	EX:NotSupportedException
+money	lv	uah	5000	EX:NotSupportedException
+money	lv	uah	21000	EX:NotSupportedException
+money	lv	uah	22000	EX:NotSupportedException
+money	lv	uah	41000	EX:NotSupportedException
+money	lv	uah	42000	EX:NotSupportedException
+money	lv	uah	100000	EX:NotSupportedException
+money	lv	uah	1000000	EX:NotSupportedException
+money	lv	uah	2000000	EX:NotSupportedException
+money	lv	uah	1000000000	EX:NotSupportedException
+money	lv	uah	123.45	EX:NotSupportedException
+money	lv	uah	-1	EX:NotSupportedException
+money	lv	uah	-2	EX:NotSupportedException
+money	lv	uah	-41.5	EX:NotSupportedException
+money	lv	uah	-1000	EX:NotSupportedException
+money	lv	uah	1.999	EX:NotSupportedException
+money	lv	uah	123.456	EX:NotSupportedException
+money	lv	uah	1.005	EX:NotSupportedException
+money	lv	bgn	0	EX:NotSupportedException
+money	lv	bgn	0.01	EX:NotSupportedException
+money	lv	bgn	0.02	EX:NotSupportedException
+money	lv	bgn	1	EX:NotSupportedException
+money	lv	bgn	1.01	EX:NotSupportedException
+money	lv	bgn	1.02	EX:NotSupportedException
+money	lv	bgn	2	EX:NotSupportedException
+money	lv	bgn	2.02	EX:NotSupportedException
+money	lv	bgn	3	EX:NotSupportedException
+money	lv	bgn	5	EX:NotSupportedException
+money	lv	bgn	11	EX:NotSupportedException
+money	lv	bgn	21	EX:NotSupportedException
+money	lv	bgn	22	EX:NotSupportedException
+money	lv	bgn	42	EX:NotSupportedException
+money	lv	bgn	100	EX:NotSupportedException
+money	lv	bgn	101	EX:NotSupportedException
+money	lv	bgn	121	EX:NotSupportedException
+money	lv	bgn	999	EX:NotSupportedException
+money	lv	bgn	1000	EX:NotSupportedException
+money	lv	bgn	1001	EX:NotSupportedException
+money	lv	bgn	2000	EX:NotSupportedException
+money	lv	bgn	2001	EX:NotSupportedException
+money	lv	bgn	5000	EX:NotSupportedException
+money	lv	bgn	21000	EX:NotSupportedException
+money	lv	bgn	22000	EX:NotSupportedException
+money	lv	bgn	41000	EX:NotSupportedException
+money	lv	bgn	42000	EX:NotSupportedException
+money	lv	bgn	100000	EX:NotSupportedException
+money	lv	bgn	1000000	EX:NotSupportedException
+money	lv	bgn	2000000	EX:NotSupportedException
+money	lv	bgn	1000000000	EX:NotSupportedException
+money	lv	bgn	123.45	EX:NotSupportedException
+money	lv	bgn	-1	EX:NotSupportedException
+money	lv	bgn	-2	EX:NotSupportedException
+money	lv	bgn	-41.5	EX:NotSupportedException
+money	lv	bgn	-1000	EX:NotSupportedException
+money	lv	bgn	1.999	EX:NotSupportedException
+money	lv	bgn	123.456	EX:NotSupportedException
+money	lv	bgn	1.005	EX:NotSupportedException
+money	lv	etb	0	EX:NotSupportedException
+money	lv	etb	0.01	EX:NotSupportedException
+money	lv	etb	0.02	EX:NotSupportedException
+money	lv	etb	1	EX:NotSupportedException
+money	lv	etb	1.01	EX:NotSupportedException
+money	lv	etb	1.02	EX:NotSupportedException
+money	lv	etb	2	EX:NotSupportedException
+money	lv	etb	2.02	EX:NotSupportedException
+money	lv	etb	3	EX:NotSupportedException
+money	lv	etb	5	EX:NotSupportedException
+money	lv	etb	11	EX:NotSupportedException
+money	lv	etb	21	EX:NotSupportedException
+money	lv	etb	22	EX:NotSupportedException
+money	lv	etb	42	EX:NotSupportedException
+money	lv	etb	100	EX:NotSupportedException
+money	lv	etb	101	EX:NotSupportedException
+money	lv	etb	121	EX:NotSupportedException
+money	lv	etb	999	EX:NotSupportedException
+money	lv	etb	1000	EX:NotSupportedException
+money	lv	etb	1001	EX:NotSupportedException
+money	lv	etb	2000	EX:NotSupportedException
+money	lv	etb	2001	EX:NotSupportedException
+money	lv	etb	5000	EX:NotSupportedException
+money	lv	etb	21000	EX:NotSupportedException
+money	lv	etb	22000	EX:NotSupportedException
+money	lv	etb	41000	EX:NotSupportedException
+money	lv	etb	42000	EX:NotSupportedException
+money	lv	etb	100000	EX:NotSupportedException
+money	lv	etb	1000000	EX:NotSupportedException
+money	lv	etb	2000000	EX:NotSupportedException
+money	lv	etb	1000000000	EX:NotSupportedException
+money	lv	etb	123.45	EX:NotSupportedException
+money	lv	etb	-1	EX:NotSupportedException
+money	lv	etb	-2	EX:NotSupportedException
+money	lv	etb	-41.5	EX:NotSupportedException
+money	lv	etb	-1000	EX:NotSupportedException
+money	lv	etb	1.999	EX:NotSupportedException
+money	lv	etb	123.456	EX:NotSupportedException
+money	lv	etb	1.005	EX:NotSupportedException
 money	lv	pln	0	nulle Polijas zlotu un nulle grašu
 money	lv	pln	0.01	nulle Polijas zlotu un viens grasis
 money	lv	pln	0.02	nulle Polijas zlotu un divi graši
@@ -7335,162 +7335,162 @@ money	lv	pln	-1000	mīnus viens tūkstotis Polijas zloti un nulle grašu
 money	lv	pln	1.999	divi Polijas zloti un nulle grašu
 money	lv	pln	123.456	simts divdesmit trīs Polijas zloti un četrdesmit seši graši
 money	lv	pln	1.005	viens Polijas zlots un viens grasis
-money	lv	byn	0	
-money	lv	byn	0.01	
-money	lv	byn	0.02	
-money	lv	byn	1	
-money	lv	byn	1.01	
-money	lv	byn	1.02	
-money	lv	byn	2	
-money	lv	byn	2.02	
-money	lv	byn	3	
-money	lv	byn	5	
-money	lv	byn	11	
-money	lv	byn	21	
-money	lv	byn	22	
-money	lv	byn	42	
-money	lv	byn	100	
-money	lv	byn	101	
-money	lv	byn	121	
-money	lv	byn	999	
-money	lv	byn	1000	
-money	lv	byn	1001	
-money	lv	byn	2000	
-money	lv	byn	2001	
-money	lv	byn	5000	
-money	lv	byn	21000	
-money	lv	byn	22000	
-money	lv	byn	41000	
-money	lv	byn	42000	
-money	lv	byn	100000	
-money	lv	byn	1000000	
-money	lv	byn	2000000	
-money	lv	byn	1000000000	
-money	lv	byn	123.45	
-money	lv	byn	-1	
-money	lv	byn	-2	
-money	lv	byn	-41.5	
-money	lv	byn	-1000	
-money	lv	byn	1.999	
-money	lv	byn	123.456	
-money	lv	byn	1.005	
-money	lv	ars	0	
-money	lv	ars	0.01	
-money	lv	ars	0.02	
-money	lv	ars	1	
-money	lv	ars	1.01	
-money	lv	ars	1.02	
-money	lv	ars	2	
-money	lv	ars	2.02	
-money	lv	ars	3	
-money	lv	ars	5	
-money	lv	ars	11	
-money	lv	ars	21	
-money	lv	ars	22	
-money	lv	ars	42	
-money	lv	ars	100	
-money	lv	ars	101	
-money	lv	ars	121	
-money	lv	ars	999	
-money	lv	ars	1000	
-money	lv	ars	1001	
-money	lv	ars	2000	
-money	lv	ars	2001	
-money	lv	ars	5000	
-money	lv	ars	21000	
-money	lv	ars	22000	
-money	lv	ars	41000	
-money	lv	ars	42000	
-money	lv	ars	100000	
-money	lv	ars	1000000	
-money	lv	ars	2000000	
-money	lv	ars	1000000000	
-money	lv	ars	123.45	
-money	lv	ars	-1	
-money	lv	ars	-2	
-money	lv	ars	-41.5	
-money	lv	ars	-1000	
-money	lv	ars	1.999	
-money	lv	ars	123.456	
-money	lv	ars	1.005	
-money	lv	brl	0	
-money	lv	brl	0.01	
-money	lv	brl	0.02	
-money	lv	brl	1	
-money	lv	brl	1.01	
-money	lv	brl	1.02	
-money	lv	brl	2	
-money	lv	brl	2.02	
-money	lv	brl	3	
-money	lv	brl	5	
-money	lv	brl	11	
-money	lv	brl	21	
-money	lv	brl	22	
-money	lv	brl	42	
-money	lv	brl	100	
-money	lv	brl	101	
-money	lv	brl	121	
-money	lv	brl	999	
-money	lv	brl	1000	
-money	lv	brl	1001	
-money	lv	brl	2000	
-money	lv	brl	2001	
-money	lv	brl	5000	
-money	lv	brl	21000	
-money	lv	brl	22000	
-money	lv	brl	41000	
-money	lv	brl	42000	
-money	lv	brl	100000	
-money	lv	brl	1000000	
-money	lv	brl	2000000	
-money	lv	brl	1000000000	
-money	lv	brl	123.45	
-money	lv	brl	-1	
-money	lv	brl	-2	
-money	lv	brl	-41.5	
-money	lv	brl	-1000	
-money	lv	brl	1.999	
-money	lv	brl	123.456	
-money	lv	brl	1.005	
-money	lv	uzs	0	
-money	lv	uzs	0.01	
-money	lv	uzs	0.02	
-money	lv	uzs	1	
-money	lv	uzs	1.01	
-money	lv	uzs	1.02	
-money	lv	uzs	2	
-money	lv	uzs	2.02	
-money	lv	uzs	3	
-money	lv	uzs	5	
-money	lv	uzs	11	
-money	lv	uzs	21	
-money	lv	uzs	22	
-money	lv	uzs	42	
-money	lv	uzs	100	
-money	lv	uzs	101	
-money	lv	uzs	121	
-money	lv	uzs	999	
-money	lv	uzs	1000	
-money	lv	uzs	1001	
-money	lv	uzs	2000	
-money	lv	uzs	2001	
-money	lv	uzs	5000	
-money	lv	uzs	21000	
-money	lv	uzs	22000	
-money	lv	uzs	41000	
-money	lv	uzs	42000	
-money	lv	uzs	100000	
-money	lv	uzs	1000000	
-money	lv	uzs	2000000	
-money	lv	uzs	1000000000	
-money	lv	uzs	123.45	
-money	lv	uzs	-1	
-money	lv	uzs	-2	
-money	lv	uzs	-41.5	
-money	lv	uzs	-1000	
-money	lv	uzs	1.999	
-money	lv	uzs	123.456	
-money	lv	uzs	1.005	
+money	lv	byn	0	EX:NotSupportedException
+money	lv	byn	0.01	EX:NotSupportedException
+money	lv	byn	0.02	EX:NotSupportedException
+money	lv	byn	1	EX:NotSupportedException
+money	lv	byn	1.01	EX:NotSupportedException
+money	lv	byn	1.02	EX:NotSupportedException
+money	lv	byn	2	EX:NotSupportedException
+money	lv	byn	2.02	EX:NotSupportedException
+money	lv	byn	3	EX:NotSupportedException
+money	lv	byn	5	EX:NotSupportedException
+money	lv	byn	11	EX:NotSupportedException
+money	lv	byn	21	EX:NotSupportedException
+money	lv	byn	22	EX:NotSupportedException
+money	lv	byn	42	EX:NotSupportedException
+money	lv	byn	100	EX:NotSupportedException
+money	lv	byn	101	EX:NotSupportedException
+money	lv	byn	121	EX:NotSupportedException
+money	lv	byn	999	EX:NotSupportedException
+money	lv	byn	1000	EX:NotSupportedException
+money	lv	byn	1001	EX:NotSupportedException
+money	lv	byn	2000	EX:NotSupportedException
+money	lv	byn	2001	EX:NotSupportedException
+money	lv	byn	5000	EX:NotSupportedException
+money	lv	byn	21000	EX:NotSupportedException
+money	lv	byn	22000	EX:NotSupportedException
+money	lv	byn	41000	EX:NotSupportedException
+money	lv	byn	42000	EX:NotSupportedException
+money	lv	byn	100000	EX:NotSupportedException
+money	lv	byn	1000000	EX:NotSupportedException
+money	lv	byn	2000000	EX:NotSupportedException
+money	lv	byn	1000000000	EX:NotSupportedException
+money	lv	byn	123.45	EX:NotSupportedException
+money	lv	byn	-1	EX:NotSupportedException
+money	lv	byn	-2	EX:NotSupportedException
+money	lv	byn	-41.5	EX:NotSupportedException
+money	lv	byn	-1000	EX:NotSupportedException
+money	lv	byn	1.999	EX:NotSupportedException
+money	lv	byn	123.456	EX:NotSupportedException
+money	lv	byn	1.005	EX:NotSupportedException
+money	lv	ars	0	EX:NotSupportedException
+money	lv	ars	0.01	EX:NotSupportedException
+money	lv	ars	0.02	EX:NotSupportedException
+money	lv	ars	1	EX:NotSupportedException
+money	lv	ars	1.01	EX:NotSupportedException
+money	lv	ars	1.02	EX:NotSupportedException
+money	lv	ars	2	EX:NotSupportedException
+money	lv	ars	2.02	EX:NotSupportedException
+money	lv	ars	3	EX:NotSupportedException
+money	lv	ars	5	EX:NotSupportedException
+money	lv	ars	11	EX:NotSupportedException
+money	lv	ars	21	EX:NotSupportedException
+money	lv	ars	22	EX:NotSupportedException
+money	lv	ars	42	EX:NotSupportedException
+money	lv	ars	100	EX:NotSupportedException
+money	lv	ars	101	EX:NotSupportedException
+money	lv	ars	121	EX:NotSupportedException
+money	lv	ars	999	EX:NotSupportedException
+money	lv	ars	1000	EX:NotSupportedException
+money	lv	ars	1001	EX:NotSupportedException
+money	lv	ars	2000	EX:NotSupportedException
+money	lv	ars	2001	EX:NotSupportedException
+money	lv	ars	5000	EX:NotSupportedException
+money	lv	ars	21000	EX:NotSupportedException
+money	lv	ars	22000	EX:NotSupportedException
+money	lv	ars	41000	EX:NotSupportedException
+money	lv	ars	42000	EX:NotSupportedException
+money	lv	ars	100000	EX:NotSupportedException
+money	lv	ars	1000000	EX:NotSupportedException
+money	lv	ars	2000000	EX:NotSupportedException
+money	lv	ars	1000000000	EX:NotSupportedException
+money	lv	ars	123.45	EX:NotSupportedException
+money	lv	ars	-1	EX:NotSupportedException
+money	lv	ars	-2	EX:NotSupportedException
+money	lv	ars	-41.5	EX:NotSupportedException
+money	lv	ars	-1000	EX:NotSupportedException
+money	lv	ars	1.999	EX:NotSupportedException
+money	lv	ars	123.456	EX:NotSupportedException
+money	lv	ars	1.005	EX:NotSupportedException
+money	lv	brl	0	EX:NotSupportedException
+money	lv	brl	0.01	EX:NotSupportedException
+money	lv	brl	0.02	EX:NotSupportedException
+money	lv	brl	1	EX:NotSupportedException
+money	lv	brl	1.01	EX:NotSupportedException
+money	lv	brl	1.02	EX:NotSupportedException
+money	lv	brl	2	EX:NotSupportedException
+money	lv	brl	2.02	EX:NotSupportedException
+money	lv	brl	3	EX:NotSupportedException
+money	lv	brl	5	EX:NotSupportedException
+money	lv	brl	11	EX:NotSupportedException
+money	lv	brl	21	EX:NotSupportedException
+money	lv	brl	22	EX:NotSupportedException
+money	lv	brl	42	EX:NotSupportedException
+money	lv	brl	100	EX:NotSupportedException
+money	lv	brl	101	EX:NotSupportedException
+money	lv	brl	121	EX:NotSupportedException
+money	lv	brl	999	EX:NotSupportedException
+money	lv	brl	1000	EX:NotSupportedException
+money	lv	brl	1001	EX:NotSupportedException
+money	lv	brl	2000	EX:NotSupportedException
+money	lv	brl	2001	EX:NotSupportedException
+money	lv	brl	5000	EX:NotSupportedException
+money	lv	brl	21000	EX:NotSupportedException
+money	lv	brl	22000	EX:NotSupportedException
+money	lv	brl	41000	EX:NotSupportedException
+money	lv	brl	42000	EX:NotSupportedException
+money	lv	brl	100000	EX:NotSupportedException
+money	lv	brl	1000000	EX:NotSupportedException
+money	lv	brl	2000000	EX:NotSupportedException
+money	lv	brl	1000000000	EX:NotSupportedException
+money	lv	brl	123.45	EX:NotSupportedException
+money	lv	brl	-1	EX:NotSupportedException
+money	lv	brl	-2	EX:NotSupportedException
+money	lv	brl	-41.5	EX:NotSupportedException
+money	lv	brl	-1000	EX:NotSupportedException
+money	lv	brl	1.999	EX:NotSupportedException
+money	lv	brl	123.456	EX:NotSupportedException
+money	lv	brl	1.005	EX:NotSupportedException
+money	lv	uzs	0	EX:NotSupportedException
+money	lv	uzs	0.01	EX:NotSupportedException
+money	lv	uzs	0.02	EX:NotSupportedException
+money	lv	uzs	1	EX:NotSupportedException
+money	lv	uzs	1.01	EX:NotSupportedException
+money	lv	uzs	1.02	EX:NotSupportedException
+money	lv	uzs	2	EX:NotSupportedException
+money	lv	uzs	2.02	EX:NotSupportedException
+money	lv	uzs	3	EX:NotSupportedException
+money	lv	uzs	5	EX:NotSupportedException
+money	lv	uzs	11	EX:NotSupportedException
+money	lv	uzs	21	EX:NotSupportedException
+money	lv	uzs	22	EX:NotSupportedException
+money	lv	uzs	42	EX:NotSupportedException
+money	lv	uzs	100	EX:NotSupportedException
+money	lv	uzs	101	EX:NotSupportedException
+money	lv	uzs	121	EX:NotSupportedException
+money	lv	uzs	999	EX:NotSupportedException
+money	lv	uzs	1000	EX:NotSupportedException
+money	lv	uzs	1001	EX:NotSupportedException
+money	lv	uzs	2000	EX:NotSupportedException
+money	lv	uzs	2001	EX:NotSupportedException
+money	lv	uzs	5000	EX:NotSupportedException
+money	lv	uzs	21000	EX:NotSupportedException
+money	lv	uzs	22000	EX:NotSupportedException
+money	lv	uzs	41000	EX:NotSupportedException
+money	lv	uzs	42000	EX:NotSupportedException
+money	lv	uzs	100000	EX:NotSupportedException
+money	lv	uzs	1000000	EX:NotSupportedException
+money	lv	uzs	2000000	EX:NotSupportedException
+money	lv	uzs	1000000000	EX:NotSupportedException
+money	lv	uzs	123.45	EX:NotSupportedException
+money	lv	uzs	-1	EX:NotSupportedException
+money	lv	uzs	-2	EX:NotSupportedException
+money	lv	uzs	-41.5	EX:NotSupportedException
+money	lv	uzs	-1000	EX:NotSupportedException
+money	lv	uzs	1.999	EX:NotSupportedException
+money	lv	uzs	123.456	EX:NotSupportedException
+money	lv	uzs	1.005	EX:NotSupportedException
 money	lv	gbp	0	nulle sterliņu mārciņu un nulle pensu
 money	lv	gbp	0.01	nulle sterliņu mārciņu un viens penss
 money	lv	gbp	0.02	nulle sterliņu mārciņu un divi pensi

--- a/src/Nut/Extentions.cs
+++ b/src/Nut/Extentions.cs
@@ -50,22 +50,42 @@ namespace Nut
             };
 
         /// <summary>Returns null for an unknown language, which callers render as "".</summary>
+        /// <summary>
+        /// An unsupported language is an error rather than an empty result. This library
+        /// writes amounts onto invoices and cheques, where a blank in the amount field is
+        /// worse than a failure: nothing surfaces it until the document is already out.
+        /// </summary>
         private static BaseConverter Resolve(string lang)
         {
             BaseConverter converter;
-            return lang != null && Converters.TryGetValue(lang, out converter) ? converter : null;
+            if (lang != null && Converters.TryGetValue(lang, out converter)) return converter;
+
+            throw new NotSupportedException(string.Format(
+                "Language '{0}' is not supported. Supported values are: {1}.",
+                lang ?? "(null)", string.Join(", ", SupportedLanguages)));
+        }
+
+        /// <summary>Every language and culture string this library accepts.</summary>
+        public static IEnumerable<string> SupportedLanguages
+        {
+            get
+            {
+                var keys = new List<string>(Converters.Keys);
+                keys.Sort(StringComparer.OrdinalIgnoreCase);
+                return keys;
+            }
         }
 
         public static string ToText(this long num, string lang = Language.Default, GenderGroup genderGroup = GenderGroup.None)
         {
             var converter = Resolve(lang);
-            return converter == null ? string.Empty : converter.ToText(num, genderGroup);
+            return converter.ToText(num, genderGroup);
         }
 
         public static string ToText(this decimal num, string currency, string lang = Language.Default, Options options = new Options(), GenderGroup genderGroup = GenderGroup.None)
         {
             var converter = Resolve(lang);
-            return converter == null ? string.Empty : converter.ToText(num, currency, options, genderGroup);
+            return converter.ToText(num, currency, options, genderGroup);
         }
 
         public static string ToText(this int num, string lang = Language.Default, GenderGroup genderGroup = GenderGroup.None)

--- a/src/Nut/TextConverters/BaseConverter.cs
+++ b/src/Nut/TextConverters/BaseConverter.cs
@@ -161,7 +161,13 @@ namespace Nut.TextConverters
       if (currency == Currency.TL) currency = Currency.TRY;
       if (currency == Currency.RUR) currency = Currency.RUB;
       var currencyModel = GetCurrencyModel(currency);
-      if (currencyModel == null) return string.Empty;
+      if (currencyModel == null)
+      {
+        // Same reasoning as an unknown language: a blank amount field on an invoice is a
+        // worse outcome than a failed call, because nothing surfaces it.
+        throw new NotSupportedException(string.Format(
+          "Currency '{0}' is not supported in {1}.", currency ?? "(null)", CultureName));
+      }
 
       // Take the sign off before splitting. Otherwise "-41.5" splits into "-41" and "5",
       // and the minus is lost somewhere in the integer part while the fraction survives,


### PR DESCRIPTION
**Breaking.** 4.0.0 is the place for it.

```
before   101.ToText("xx")              ->  ""
after                                  ->  NotSupportedException:
                                           Language 'xx' is not supported.
                                           Supported values are: am, am-ET, bg, ... uz-UZ.

before   1m.ToText("ars", "am")        ->  ""
after                                  ->  NotSupportedException:
                                           Currency 'ars' is not supported in am-ET.
```

## Why

This library writes the amount onto an invoice or a cheque. An empty string there prints as a blank field, and nothing surfaces it — not the caller, not the reviewer, not the recipient until the document is already out.

It is the same failure shape as two defects fixed earlier in this cycle: negative amounts that silently dropped their integer part, and the third decimal read as whole sub-units. Both produced something that looked like a valid amount. A blank is the same class of problem with an even quieter signal.

## Numbers

| | |
|---|---|
| Silent blanks in the snapshot | **468 → 0** |
| Money conversions producing text | 7137 |

Everything that returned text still returns the same text.

## What is left unsupported

Only combinations nobody has written words for:

- **Amharic**: ARS, BRL, GBP, UZS — I have not touched Amharic wording, as agreed.
- **Latvian**: the eight currencies it did not ship with. Worth filling in, but it is a separate piece of work and the exception makes the gap visible rather than silent.

## Migration

Catch `NotSupportedException`, or check first:

```csharp
Extentions.SupportedLanguages   // en, en-GB, en-US, tr, tr-TR, lv, ...
```

Added in this PR for exactly that.

## Verification

- 588 tests.
- A test asserts the messages actually name the problem and the alternatives, rather than just being non-empty.