### PR TITLE
feat: fill in the remaining currencies for Latvian

### DIFF
--- a/src/Nut.Tests/behaviour-snapshot.tsv
+++ b/src/Nut.Tests/behaviour-snapshot.tsv
@@ -7140,162 +7140,162 @@ money	lv	rub	-1000	mīnus viens tūkstotis Krievijas rubļi un nulle kapeiku
 money	lv	rub	1.999	divi Krievijas rubļi un nulle kapeiku
 money	lv	rub	123.456	simts divdesmit trīs Krievijas rubļi un četrdesmit seši kapeikas
 money	lv	rub	1.005	viens Krievijas rublis un viena kapeika
-money	lv	try	0	EX:NotSupportedException
-money	lv	try	0.01	EX:NotSupportedException
-money	lv	try	0.02	EX:NotSupportedException
-money	lv	try	1	EX:NotSupportedException
-money	lv	try	1.01	EX:NotSupportedException
-money	lv	try	1.02	EX:NotSupportedException
-money	lv	try	2	EX:NotSupportedException
-money	lv	try	2.02	EX:NotSupportedException
-money	lv	try	3	EX:NotSupportedException
-money	lv	try	5	EX:NotSupportedException
-money	lv	try	11	EX:NotSupportedException
-money	lv	try	21	EX:NotSupportedException
-money	lv	try	22	EX:NotSupportedException
-money	lv	try	42	EX:NotSupportedException
-money	lv	try	100	EX:NotSupportedException
-money	lv	try	101	EX:NotSupportedException
-money	lv	try	121	EX:NotSupportedException
-money	lv	try	999	EX:NotSupportedException
-money	lv	try	1000	EX:NotSupportedException
-money	lv	try	1001	EX:NotSupportedException
-money	lv	try	2000	EX:NotSupportedException
-money	lv	try	2001	EX:NotSupportedException
-money	lv	try	5000	EX:NotSupportedException
-money	lv	try	21000	EX:NotSupportedException
-money	lv	try	22000	EX:NotSupportedException
-money	lv	try	41000	EX:NotSupportedException
-money	lv	try	42000	EX:NotSupportedException
-money	lv	try	100000	EX:NotSupportedException
-money	lv	try	1000000	EX:NotSupportedException
-money	lv	try	2000000	EX:NotSupportedException
-money	lv	try	1000000000	EX:NotSupportedException
-money	lv	try	123.45	EX:NotSupportedException
-money	lv	try	-1	EX:NotSupportedException
-money	lv	try	-2	EX:NotSupportedException
-money	lv	try	-41.5	EX:NotSupportedException
-money	lv	try	-1000	EX:NotSupportedException
-money	lv	try	1.999	EX:NotSupportedException
-money	lv	try	123.456	EX:NotSupportedException
-money	lv	try	1.005	EX:NotSupportedException
-money	lv	uah	0	EX:NotSupportedException
-money	lv	uah	0.01	EX:NotSupportedException
-money	lv	uah	0.02	EX:NotSupportedException
-money	lv	uah	1	EX:NotSupportedException
-money	lv	uah	1.01	EX:NotSupportedException
-money	lv	uah	1.02	EX:NotSupportedException
-money	lv	uah	2	EX:NotSupportedException
-money	lv	uah	2.02	EX:NotSupportedException
-money	lv	uah	3	EX:NotSupportedException
-money	lv	uah	5	EX:NotSupportedException
-money	lv	uah	11	EX:NotSupportedException
-money	lv	uah	21	EX:NotSupportedException
-money	lv	uah	22	EX:NotSupportedException
-money	lv	uah	42	EX:NotSupportedException
-money	lv	uah	100	EX:NotSupportedException
-money	lv	uah	101	EX:NotSupportedException
-money	lv	uah	121	EX:NotSupportedException
-money	lv	uah	999	EX:NotSupportedException
-money	lv	uah	1000	EX:NotSupportedException
-money	lv	uah	1001	EX:NotSupportedException
-money	lv	uah	2000	EX:NotSupportedException
-money	lv	uah	2001	EX:NotSupportedException
-money	lv	uah	5000	EX:NotSupportedException
-money	lv	uah	21000	EX:NotSupportedException
-money	lv	uah	22000	EX:NotSupportedException
-money	lv	uah	41000	EX:NotSupportedException
-money	lv	uah	42000	EX:NotSupportedException
-money	lv	uah	100000	EX:NotSupportedException
-money	lv	uah	1000000	EX:NotSupportedException
-money	lv	uah	2000000	EX:NotSupportedException
-money	lv	uah	1000000000	EX:NotSupportedException
-money	lv	uah	123.45	EX:NotSupportedException
-money	lv	uah	-1	EX:NotSupportedException
-money	lv	uah	-2	EX:NotSupportedException
-money	lv	uah	-41.5	EX:NotSupportedException
-money	lv	uah	-1000	EX:NotSupportedException
-money	lv	uah	1.999	EX:NotSupportedException
-money	lv	uah	123.456	EX:NotSupportedException
-money	lv	uah	1.005	EX:NotSupportedException
-money	lv	bgn	0	EX:NotSupportedException
-money	lv	bgn	0.01	EX:NotSupportedException
-money	lv	bgn	0.02	EX:NotSupportedException
-money	lv	bgn	1	EX:NotSupportedException
-money	lv	bgn	1.01	EX:NotSupportedException
-money	lv	bgn	1.02	EX:NotSupportedException
-money	lv	bgn	2	EX:NotSupportedException
-money	lv	bgn	2.02	EX:NotSupportedException
-money	lv	bgn	3	EX:NotSupportedException
-money	lv	bgn	5	EX:NotSupportedException
-money	lv	bgn	11	EX:NotSupportedException
-money	lv	bgn	21	EX:NotSupportedException
-money	lv	bgn	22	EX:NotSupportedException
-money	lv	bgn	42	EX:NotSupportedException
-money	lv	bgn	100	EX:NotSupportedException
-money	lv	bgn	101	EX:NotSupportedException
-money	lv	bgn	121	EX:NotSupportedException
-money	lv	bgn	999	EX:NotSupportedException
-money	lv	bgn	1000	EX:NotSupportedException
-money	lv	bgn	1001	EX:NotSupportedException
-money	lv	bgn	2000	EX:NotSupportedException
-money	lv	bgn	2001	EX:NotSupportedException
-money	lv	bgn	5000	EX:NotSupportedException
-money	lv	bgn	21000	EX:NotSupportedException
-money	lv	bgn	22000	EX:NotSupportedException
-money	lv	bgn	41000	EX:NotSupportedException
-money	lv	bgn	42000	EX:NotSupportedException
-money	lv	bgn	100000	EX:NotSupportedException
-money	lv	bgn	1000000	EX:NotSupportedException
-money	lv	bgn	2000000	EX:NotSupportedException
-money	lv	bgn	1000000000	EX:NotSupportedException
-money	lv	bgn	123.45	EX:NotSupportedException
-money	lv	bgn	-1	EX:NotSupportedException
-money	lv	bgn	-2	EX:NotSupportedException
-money	lv	bgn	-41.5	EX:NotSupportedException
-money	lv	bgn	-1000	EX:NotSupportedException
-money	lv	bgn	1.999	EX:NotSupportedException
-money	lv	bgn	123.456	EX:NotSupportedException
-money	lv	bgn	1.005	EX:NotSupportedException
-money	lv	etb	0	EX:NotSupportedException
-money	lv	etb	0.01	EX:NotSupportedException
-money	lv	etb	0.02	EX:NotSupportedException
-money	lv	etb	1	EX:NotSupportedException
-money	lv	etb	1.01	EX:NotSupportedException
-money	lv	etb	1.02	EX:NotSupportedException
-money	lv	etb	2	EX:NotSupportedException
-money	lv	etb	2.02	EX:NotSupportedException
-money	lv	etb	3	EX:NotSupportedException
-money	lv	etb	5	EX:NotSupportedException
-money	lv	etb	11	EX:NotSupportedException
-money	lv	etb	21	EX:NotSupportedException
-money	lv	etb	22	EX:NotSupportedException
-money	lv	etb	42	EX:NotSupportedException
-money	lv	etb	100	EX:NotSupportedException
-money	lv	etb	101	EX:NotSupportedException
-money	lv	etb	121	EX:NotSupportedException
-money	lv	etb	999	EX:NotSupportedException
-money	lv	etb	1000	EX:NotSupportedException
-money	lv	etb	1001	EX:NotSupportedException
-money	lv	etb	2000	EX:NotSupportedException
-money	lv	etb	2001	EX:NotSupportedException
-money	lv	etb	5000	EX:NotSupportedException
-money	lv	etb	21000	EX:NotSupportedException
-money	lv	etb	22000	EX:NotSupportedException
-money	lv	etb	41000	EX:NotSupportedException
-money	lv	etb	42000	EX:NotSupportedException
-money	lv	etb	100000	EX:NotSupportedException
-money	lv	etb	1000000	EX:NotSupportedException
-money	lv	etb	2000000	EX:NotSupportedException
-money	lv	etb	1000000000	EX:NotSupportedException
-money	lv	etb	123.45	EX:NotSupportedException
-money	lv	etb	-1	EX:NotSupportedException
-money	lv	etb	-2	EX:NotSupportedException
-money	lv	etb	-41.5	EX:NotSupportedException
-money	lv	etb	-1000	EX:NotSupportedException
-money	lv	etb	1.999	EX:NotSupportedException
-money	lv	etb	123.456	EX:NotSupportedException
-money	lv	etb	1.005	EX:NotSupportedException
+money	lv	try	0	nulle Turcijas liru un nulle kurusu
+money	lv	try	0.01	nulle Turcijas liru un viens kuruss
+money	lv	try	0.02	nulle Turcijas liru un divi kurusi
+money	lv	try	1	viena Turcijas lira un nulle kurusu
+money	lv	try	1.01	viena Turcijas lira un viens kuruss
+money	lv	try	1.02	viena Turcijas lira un divi kurusi
+money	lv	try	2	divas Turcijas liras un nulle kurusu
+money	lv	try	2.02	divas Turcijas liras un divi kurusi
+money	lv	try	3	trīs Turcijas liras un nulle kurusu
+money	lv	try	5	pieci Turcijas liras un nulle kurusu
+money	lv	try	11	vienpadsmit Turcijas liras un nulle kurusu
+money	lv	try	21	divdesmit viena Turcijas lira un nulle kurusu
+money	lv	try	22	divdesmit divas Turcijas liras un nulle kurusu
+money	lv	try	42	četrdesmit divas Turcijas liras un nulle kurusu
+money	lv	try	100	simts Turcijas liras un nulle kurusu
+money	lv	try	101	simts viena Turcijas lira un nulle kurusu
+money	lv	try	121	simts divdesmit viena Turcijas lira un nulle kurusu
+money	lv	try	999	deviņi simti deviņdesmit deviņi Turcijas liras un nulle kurusu
+money	lv	try	1000	viena tūkstotis Turcijas liras un nulle kurusu
+money	lv	try	1001	viena tūkstotis viena Turcijas lira un nulle kurusu
+money	lv	try	2000	divas tūkstoši Turcijas liras un nulle kurusu
+money	lv	try	2001	divas tūkstoši viena Turcijas lira un nulle kurusu
+money	lv	try	5000	pieci tūkstoši Turcijas liras un nulle kurusu
+money	lv	try	21000	divdesmit viena tūkstoši Turcijas liras un nulle kurusu
+money	lv	try	22000	divdesmit divas tūkstoši Turcijas liras un nulle kurusu
+money	lv	try	41000	četrdesmit viena tūkstoši Turcijas liras un nulle kurusu
+money	lv	try	42000	četrdesmit divas tūkstoši Turcijas liras un nulle kurusu
+money	lv	try	100000	simts tūkstoši Turcijas liras un nulle kurusu
+money	lv	try	1000000	viena miljons Turcijas liras un nulle kurusu
+money	lv	try	2000000	divas miljoni Turcijas liras un nulle kurusu
+money	lv	try	1000000000	viena miljards Turcijas liras un nulle kurusu
+money	lv	try	123.45	simts divdesmit trīs Turcijas liras un četrdesmit pieci kurusi
+money	lv	try	-1	mīnus viena Turcijas lira un nulle kurusu
+money	lv	try	-2	mīnus divas Turcijas liras un nulle kurusu
+money	lv	try	-41.5	mīnus četrdesmit viena Turcijas lira un piecdesmit kurusi
+money	lv	try	-1000	mīnus viena tūkstotis Turcijas liras un nulle kurusu
+money	lv	try	1.999	divas Turcijas liras un nulle kurusu
+money	lv	try	123.456	simts divdesmit trīs Turcijas liras un četrdesmit seši kurusi
+money	lv	try	1.005	viena Turcijas lira un viens kuruss
+money	lv	uah	0	nulle Ukrainas grivnu un nulle kapeiku
+money	lv	uah	0.01	nulle Ukrainas grivnu un viena kapeika
+money	lv	uah	0.02	nulle Ukrainas grivnu un divas kapeikas
+money	lv	uah	1	viena Ukrainas grivna un nulle kapeiku
+money	lv	uah	1.01	viena Ukrainas grivna un viena kapeika
+money	lv	uah	1.02	viena Ukrainas grivna un divas kapeikas
+money	lv	uah	2	divas Ukrainas grivnas un nulle kapeiku
+money	lv	uah	2.02	divas Ukrainas grivnas un divas kapeikas
+money	lv	uah	3	trīs Ukrainas grivnas un nulle kapeiku
+money	lv	uah	5	pieci Ukrainas grivnas un nulle kapeiku
+money	lv	uah	11	vienpadsmit Ukrainas grivnas un nulle kapeiku
+money	lv	uah	21	divdesmit viena Ukrainas grivna un nulle kapeiku
+money	lv	uah	22	divdesmit divas Ukrainas grivnas un nulle kapeiku
+money	lv	uah	42	četrdesmit divas Ukrainas grivnas un nulle kapeiku
+money	lv	uah	100	simts Ukrainas grivnas un nulle kapeiku
+money	lv	uah	101	simts viena Ukrainas grivna un nulle kapeiku
+money	lv	uah	121	simts divdesmit viena Ukrainas grivna un nulle kapeiku
+money	lv	uah	999	deviņi simti deviņdesmit deviņi Ukrainas grivnas un nulle kapeiku
+money	lv	uah	1000	viena tūkstotis Ukrainas grivnas un nulle kapeiku
+money	lv	uah	1001	viena tūkstotis viena Ukrainas grivna un nulle kapeiku
+money	lv	uah	2000	divas tūkstoši Ukrainas grivnas un nulle kapeiku
+money	lv	uah	2001	divas tūkstoši viena Ukrainas grivna un nulle kapeiku
+money	lv	uah	5000	pieci tūkstoši Ukrainas grivnas un nulle kapeiku
+money	lv	uah	21000	divdesmit viena tūkstoši Ukrainas grivnas un nulle kapeiku
+money	lv	uah	22000	divdesmit divas tūkstoši Ukrainas grivnas un nulle kapeiku
+money	lv	uah	41000	četrdesmit viena tūkstoši Ukrainas grivnas un nulle kapeiku
+money	lv	uah	42000	četrdesmit divas tūkstoši Ukrainas grivnas un nulle kapeiku
+money	lv	uah	100000	simts tūkstoši Ukrainas grivnas un nulle kapeiku
+money	lv	uah	1000000	viena miljons Ukrainas grivnas un nulle kapeiku
+money	lv	uah	2000000	divas miljoni Ukrainas grivnas un nulle kapeiku
+money	lv	uah	1000000000	viena miljards Ukrainas grivnas un nulle kapeiku
+money	lv	uah	123.45	simts divdesmit trīs Ukrainas grivnas un četrdesmit pieci kapeikas
+money	lv	uah	-1	mīnus viena Ukrainas grivna un nulle kapeiku
+money	lv	uah	-2	mīnus divas Ukrainas grivnas un nulle kapeiku
+money	lv	uah	-41.5	mīnus četrdesmit viena Ukrainas grivna un piecdesmit kapeikas
+money	lv	uah	-1000	mīnus viena tūkstotis Ukrainas grivnas un nulle kapeiku
+money	lv	uah	1.999	divas Ukrainas grivnas un nulle kapeiku
+money	lv	uah	123.456	simts divdesmit trīs Ukrainas grivnas un četrdesmit seši kapeikas
+money	lv	uah	1.005	viena Ukrainas grivna un viena kapeika
+money	lv	bgn	0	nulle Bulgārijas levu un nulle stotinku
+money	lv	bgn	0.01	nulle Bulgārijas levu un viena stotinka
+money	lv	bgn	0.02	nulle Bulgārijas levu un divas stotinkas
+money	lv	bgn	1	viena Bulgārijas leva un nulle stotinku
+money	lv	bgn	1.01	viena Bulgārijas leva un viena stotinka
+money	lv	bgn	1.02	viena Bulgārijas leva un divas stotinkas
+money	lv	bgn	2	divas Bulgārijas levas un nulle stotinku
+money	lv	bgn	2.02	divas Bulgārijas levas un divas stotinkas
+money	lv	bgn	3	trīs Bulgārijas levas un nulle stotinku
+money	lv	bgn	5	pieci Bulgārijas levas un nulle stotinku
+money	lv	bgn	11	vienpadsmit Bulgārijas levas un nulle stotinku
+money	lv	bgn	21	divdesmit viena Bulgārijas leva un nulle stotinku
+money	lv	bgn	22	divdesmit divas Bulgārijas levas un nulle stotinku
+money	lv	bgn	42	četrdesmit divas Bulgārijas levas un nulle stotinku
+money	lv	bgn	100	simts Bulgārijas levas un nulle stotinku
+money	lv	bgn	101	simts viena Bulgārijas leva un nulle stotinku
+money	lv	bgn	121	simts divdesmit viena Bulgārijas leva un nulle stotinku
+money	lv	bgn	999	deviņi simti deviņdesmit deviņi Bulgārijas levas un nulle stotinku
+money	lv	bgn	1000	viena tūkstotis Bulgārijas levas un nulle stotinku
+money	lv	bgn	1001	viena tūkstotis viena Bulgārijas leva un nulle stotinku
+money	lv	bgn	2000	divas tūkstoši Bulgārijas levas un nulle stotinku
+money	lv	bgn	2001	divas tūkstoši viena Bulgārijas leva un nulle stotinku
+money	lv	bgn	5000	pieci tūkstoši Bulgārijas levas un nulle stotinku
+money	lv	bgn	21000	divdesmit viena tūkstoši Bulgārijas levas un nulle stotinku
+money	lv	bgn	22000	divdesmit divas tūkstoši Bulgārijas levas un nulle stotinku
+money	lv	bgn	41000	četrdesmit viena tūkstoši Bulgārijas levas un nulle stotinku
+money	lv	bgn	42000	četrdesmit divas tūkstoši Bulgārijas levas un nulle stotinku
+money	lv	bgn	100000	simts tūkstoši Bulgārijas levas un nulle stotinku
+money	lv	bgn	1000000	viena miljons Bulgārijas levas un nulle stotinku
+money	lv	bgn	2000000	divas miljoni Bulgārijas levas un nulle stotinku
+money	lv	bgn	1000000000	viena miljards Bulgārijas levas un nulle stotinku
+money	lv	bgn	123.45	simts divdesmit trīs Bulgārijas levas un četrdesmit pieci stotinkas
+money	lv	bgn	-1	mīnus viena Bulgārijas leva un nulle stotinku
+money	lv	bgn	-2	mīnus divas Bulgārijas levas un nulle stotinku
+money	lv	bgn	-41.5	mīnus četrdesmit viena Bulgārijas leva un piecdesmit stotinkas
+money	lv	bgn	-1000	mīnus viena tūkstotis Bulgārijas levas un nulle stotinku
+money	lv	bgn	1.999	divas Bulgārijas levas un nulle stotinku
+money	lv	bgn	123.456	simts divdesmit trīs Bulgārijas levas un četrdesmit seši stotinkas
+money	lv	bgn	1.005	viena Bulgārijas leva un viena stotinka
+money	lv	etb	0	nulle Etiopijas biru un nulle santīmu
+money	lv	etb	0.01	nulle Etiopijas biru un viens santīms
+money	lv	etb	0.02	nulle Etiopijas biru un divi santīmi
+money	lv	etb	1	viens Etiopijas birs un nulle santīmu
+money	lv	etb	1.01	viens Etiopijas birs un viens santīms
+money	lv	etb	1.02	viens Etiopijas birs un divi santīmi
+money	lv	etb	2	divi Etiopijas biri un nulle santīmu
+money	lv	etb	2.02	divi Etiopijas biri un divi santīmi
+money	lv	etb	3	trīs Etiopijas biri un nulle santīmu
+money	lv	etb	5	pieci Etiopijas biri un nulle santīmu
+money	lv	etb	11	vienpadsmit Etiopijas biri un nulle santīmu
+money	lv	etb	21	divdesmit viens Etiopijas birs un nulle santīmu
+money	lv	etb	22	divdesmit divi Etiopijas biri un nulle santīmu
+money	lv	etb	42	četrdesmit divi Etiopijas biri un nulle santīmu
+money	lv	etb	100	simts Etiopijas biri un nulle santīmu
+money	lv	etb	101	simts viens Etiopijas birs un nulle santīmu
+money	lv	etb	121	simts divdesmit viens Etiopijas birs un nulle santīmu
+money	lv	etb	999	deviņi simti deviņdesmit deviņi Etiopijas biri un nulle santīmu
+money	lv	etb	1000	viens tūkstotis Etiopijas biri un nulle santīmu
+money	lv	etb	1001	viens tūkstotis viens Etiopijas birs un nulle santīmu
+money	lv	etb	2000	divi tūkstoši Etiopijas biri un nulle santīmu
+money	lv	etb	2001	divi tūkstoši viens Etiopijas birs un nulle santīmu
+money	lv	etb	5000	pieci tūkstoši Etiopijas biri un nulle santīmu
+money	lv	etb	21000	divdesmit viens tūkstoši Etiopijas biri un nulle santīmu
+money	lv	etb	22000	divdesmit divi tūkstoši Etiopijas biri un nulle santīmu
+money	lv	etb	41000	četrdesmit viens tūkstoši Etiopijas biri un nulle santīmu
+money	lv	etb	42000	četrdesmit divi tūkstoši Etiopijas biri un nulle santīmu
+money	lv	etb	100000	simts tūkstoši Etiopijas biri un nulle santīmu
+money	lv	etb	1000000	viens miljons Etiopijas biri un nulle santīmu
+money	lv	etb	2000000	divi miljoni Etiopijas biri un nulle santīmu
+money	lv	etb	1000000000	viens miljards Etiopijas biri un nulle santīmu
+money	lv	etb	123.45	simts divdesmit trīs Etiopijas biri un četrdesmit pieci santīmi
+money	lv	etb	-1	mīnus viens Etiopijas birs un nulle santīmu
+money	lv	etb	-2	mīnus divi Etiopijas biri un nulle santīmu
+money	lv	etb	-41.5	mīnus četrdesmit viens Etiopijas birs un piecdesmit santīmi
+money	lv	etb	-1000	mīnus viens tūkstotis Etiopijas biri un nulle santīmu
+money	lv	etb	1.999	divi Etiopijas biri un nulle santīmu
+money	lv	etb	123.456	simts divdesmit trīs Etiopijas biri un četrdesmit seši santīmi
+money	lv	etb	1.005	viens Etiopijas birs un viens santīms
 money	lv	pln	0	nulle Polijas zlotu un nulle grašu
 money	lv	pln	0.01	nulle Polijas zlotu un viens grasis
 money	lv	pln	0.02	nulle Polijas zlotu un divi graši
@@ -7335,162 +7335,162 @@ money	lv	pln	-1000	mīnus viens tūkstotis Polijas zloti un nulle grašu
 money	lv	pln	1.999	divi Polijas zloti un nulle grašu
 money	lv	pln	123.456	simts divdesmit trīs Polijas zloti un četrdesmit seši graši
 money	lv	pln	1.005	viens Polijas zlots un viens grasis
-money	lv	byn	0	EX:NotSupportedException
-money	lv	byn	0.01	EX:NotSupportedException
-money	lv	byn	0.02	EX:NotSupportedException
-money	lv	byn	1	EX:NotSupportedException
-money	lv	byn	1.01	EX:NotSupportedException
-money	lv	byn	1.02	EX:NotSupportedException
-money	lv	byn	2	EX:NotSupportedException
-money	lv	byn	2.02	EX:NotSupportedException
-money	lv	byn	3	EX:NotSupportedException
-money	lv	byn	5	EX:NotSupportedException
-money	lv	byn	11	EX:NotSupportedException
-money	lv	byn	21	EX:NotSupportedException
-money	lv	byn	22	EX:NotSupportedException
-money	lv	byn	42	EX:NotSupportedException
-money	lv	byn	100	EX:NotSupportedException
-money	lv	byn	101	EX:NotSupportedException
-money	lv	byn	121	EX:NotSupportedException
-money	lv	byn	999	EX:NotSupportedException
-money	lv	byn	1000	EX:NotSupportedException
-money	lv	byn	1001	EX:NotSupportedException
-money	lv	byn	2000	EX:NotSupportedException
-money	lv	byn	2001	EX:NotSupportedException
-money	lv	byn	5000	EX:NotSupportedException
-money	lv	byn	21000	EX:NotSupportedException
-money	lv	byn	22000	EX:NotSupportedException
-money	lv	byn	41000	EX:NotSupportedException
-money	lv	byn	42000	EX:NotSupportedException
-money	lv	byn	100000	EX:NotSupportedException
-money	lv	byn	1000000	EX:NotSupportedException
-money	lv	byn	2000000	EX:NotSupportedException
-money	lv	byn	1000000000	EX:NotSupportedException
-money	lv	byn	123.45	EX:NotSupportedException
-money	lv	byn	-1	EX:NotSupportedException
-money	lv	byn	-2	EX:NotSupportedException
-money	lv	byn	-41.5	EX:NotSupportedException
-money	lv	byn	-1000	EX:NotSupportedException
-money	lv	byn	1.999	EX:NotSupportedException
-money	lv	byn	123.456	EX:NotSupportedException
-money	lv	byn	1.005	EX:NotSupportedException
-money	lv	ars	0	EX:NotSupportedException
-money	lv	ars	0.01	EX:NotSupportedException
-money	lv	ars	0.02	EX:NotSupportedException
-money	lv	ars	1	EX:NotSupportedException
-money	lv	ars	1.01	EX:NotSupportedException
-money	lv	ars	1.02	EX:NotSupportedException
-money	lv	ars	2	EX:NotSupportedException
-money	lv	ars	2.02	EX:NotSupportedException
-money	lv	ars	3	EX:NotSupportedException
-money	lv	ars	5	EX:NotSupportedException
-money	lv	ars	11	EX:NotSupportedException
-money	lv	ars	21	EX:NotSupportedException
-money	lv	ars	22	EX:NotSupportedException
-money	lv	ars	42	EX:NotSupportedException
-money	lv	ars	100	EX:NotSupportedException
-money	lv	ars	101	EX:NotSupportedException
-money	lv	ars	121	EX:NotSupportedException
-money	lv	ars	999	EX:NotSupportedException
-money	lv	ars	1000	EX:NotSupportedException
-money	lv	ars	1001	EX:NotSupportedException
-money	lv	ars	2000	EX:NotSupportedException
-money	lv	ars	2001	EX:NotSupportedException
-money	lv	ars	5000	EX:NotSupportedException
-money	lv	ars	21000	EX:NotSupportedException
-money	lv	ars	22000	EX:NotSupportedException
-money	lv	ars	41000	EX:NotSupportedException
-money	lv	ars	42000	EX:NotSupportedException
-money	lv	ars	100000	EX:NotSupportedException
-money	lv	ars	1000000	EX:NotSupportedException
-money	lv	ars	2000000	EX:NotSupportedException
-money	lv	ars	1000000000	EX:NotSupportedException
-money	lv	ars	123.45	EX:NotSupportedException
-money	lv	ars	-1	EX:NotSupportedException
-money	lv	ars	-2	EX:NotSupportedException
-money	lv	ars	-41.5	EX:NotSupportedException
-money	lv	ars	-1000	EX:NotSupportedException
-money	lv	ars	1.999	EX:NotSupportedException
-money	lv	ars	123.456	EX:NotSupportedException
-money	lv	ars	1.005	EX:NotSupportedException
-money	lv	brl	0	EX:NotSupportedException
-money	lv	brl	0.01	EX:NotSupportedException
-money	lv	brl	0.02	EX:NotSupportedException
-money	lv	brl	1	EX:NotSupportedException
-money	lv	brl	1.01	EX:NotSupportedException
-money	lv	brl	1.02	EX:NotSupportedException
-money	lv	brl	2	EX:NotSupportedException
-money	lv	brl	2.02	EX:NotSupportedException
-money	lv	brl	3	EX:NotSupportedException
-money	lv	brl	5	EX:NotSupportedException
-money	lv	brl	11	EX:NotSupportedException
-money	lv	brl	21	EX:NotSupportedException
-money	lv	brl	22	EX:NotSupportedException
-money	lv	brl	42	EX:NotSupportedException
-money	lv	brl	100	EX:NotSupportedException
-money	lv	brl	101	EX:NotSupportedException
-money	lv	brl	121	EX:NotSupportedException
-money	lv	brl	999	EX:NotSupportedException
-money	lv	brl	1000	EX:NotSupportedException
-money	lv	brl	1001	EX:NotSupportedException
-money	lv	brl	2000	EX:NotSupportedException
-money	lv	brl	2001	EX:NotSupportedException
-money	lv	brl	5000	EX:NotSupportedException
-money	lv	brl	21000	EX:NotSupportedException
-money	lv	brl	22000	EX:NotSupportedException
-money	lv	brl	41000	EX:NotSupportedException
-money	lv	brl	42000	EX:NotSupportedException
-money	lv	brl	100000	EX:NotSupportedException
-money	lv	brl	1000000	EX:NotSupportedException
-money	lv	brl	2000000	EX:NotSupportedException
-money	lv	brl	1000000000	EX:NotSupportedException
-money	lv	brl	123.45	EX:NotSupportedException
-money	lv	brl	-1	EX:NotSupportedException
-money	lv	brl	-2	EX:NotSupportedException
-money	lv	brl	-41.5	EX:NotSupportedException
-money	lv	brl	-1000	EX:NotSupportedException
-money	lv	brl	1.999	EX:NotSupportedException
-money	lv	brl	123.456	EX:NotSupportedException
-money	lv	brl	1.005	EX:NotSupportedException
-money	lv	uzs	0	EX:NotSupportedException
-money	lv	uzs	0.01	EX:NotSupportedException
-money	lv	uzs	0.02	EX:NotSupportedException
-money	lv	uzs	1	EX:NotSupportedException
-money	lv	uzs	1.01	EX:NotSupportedException
-money	lv	uzs	1.02	EX:NotSupportedException
-money	lv	uzs	2	EX:NotSupportedException
-money	lv	uzs	2.02	EX:NotSupportedException
-money	lv	uzs	3	EX:NotSupportedException
-money	lv	uzs	5	EX:NotSupportedException
-money	lv	uzs	11	EX:NotSupportedException
-money	lv	uzs	21	EX:NotSupportedException
-money	lv	uzs	22	EX:NotSupportedException
-money	lv	uzs	42	EX:NotSupportedException
-money	lv	uzs	100	EX:NotSupportedException
-money	lv	uzs	101	EX:NotSupportedException
-money	lv	uzs	121	EX:NotSupportedException
-money	lv	uzs	999	EX:NotSupportedException
-money	lv	uzs	1000	EX:NotSupportedException
-money	lv	uzs	1001	EX:NotSupportedException
-money	lv	uzs	2000	EX:NotSupportedException
-money	lv	uzs	2001	EX:NotSupportedException
-money	lv	uzs	5000	EX:NotSupportedException
-money	lv	uzs	21000	EX:NotSupportedException
-money	lv	uzs	22000	EX:NotSupportedException
-money	lv	uzs	41000	EX:NotSupportedException
-money	lv	uzs	42000	EX:NotSupportedException
-money	lv	uzs	100000	EX:NotSupportedException
-money	lv	uzs	1000000	EX:NotSupportedException
-money	lv	uzs	2000000	EX:NotSupportedException
-money	lv	uzs	1000000000	EX:NotSupportedException
-money	lv	uzs	123.45	EX:NotSupportedException
-money	lv	uzs	-1	EX:NotSupportedException
-money	lv	uzs	-2	EX:NotSupportedException
-money	lv	uzs	-41.5	EX:NotSupportedException
-money	lv	uzs	-1000	EX:NotSupportedException
-money	lv	uzs	1.999	EX:NotSupportedException
-money	lv	uzs	123.456	EX:NotSupportedException
-money	lv	uzs	1.005	EX:NotSupportedException
+money	lv	byn	0	nulle Baltkrievijas rubļu un nulle kapeiku
+money	lv	byn	0.01	nulle Baltkrievijas rubļu un viena kapeika
+money	lv	byn	0.02	nulle Baltkrievijas rubļu un divas kapeikas
+money	lv	byn	1	viens Baltkrievijas rublis un nulle kapeiku
+money	lv	byn	1.01	viens Baltkrievijas rublis un viena kapeika
+money	lv	byn	1.02	viens Baltkrievijas rublis un divas kapeikas
+money	lv	byn	2	divi Baltkrievijas rubļi un nulle kapeiku
+money	lv	byn	2.02	divi Baltkrievijas rubļi un divas kapeikas
+money	lv	byn	3	trīs Baltkrievijas rubļi un nulle kapeiku
+money	lv	byn	5	pieci Baltkrievijas rubļi un nulle kapeiku
+money	lv	byn	11	vienpadsmit Baltkrievijas rubļi un nulle kapeiku
+money	lv	byn	21	divdesmit viens Baltkrievijas rublis un nulle kapeiku
+money	lv	byn	22	divdesmit divi Baltkrievijas rubļi un nulle kapeiku
+money	lv	byn	42	četrdesmit divi Baltkrievijas rubļi un nulle kapeiku
+money	lv	byn	100	simts Baltkrievijas rubļi un nulle kapeiku
+money	lv	byn	101	simts viens Baltkrievijas rublis un nulle kapeiku
+money	lv	byn	121	simts divdesmit viens Baltkrievijas rublis un nulle kapeiku
+money	lv	byn	999	deviņi simti deviņdesmit deviņi Baltkrievijas rubļi un nulle kapeiku
+money	lv	byn	1000	viens tūkstotis Baltkrievijas rubļi un nulle kapeiku
+money	lv	byn	1001	viens tūkstotis viens Baltkrievijas rublis un nulle kapeiku
+money	lv	byn	2000	divi tūkstoši Baltkrievijas rubļi un nulle kapeiku
+money	lv	byn	2001	divi tūkstoši viens Baltkrievijas rublis un nulle kapeiku
+money	lv	byn	5000	pieci tūkstoši Baltkrievijas rubļi un nulle kapeiku
+money	lv	byn	21000	divdesmit viens tūkstoši Baltkrievijas rubļi un nulle kapeiku
+money	lv	byn	22000	divdesmit divi tūkstoši Baltkrievijas rubļi un nulle kapeiku
+money	lv	byn	41000	četrdesmit viens tūkstoši Baltkrievijas rubļi un nulle kapeiku
+money	lv	byn	42000	četrdesmit divi tūkstoši Baltkrievijas rubļi un nulle kapeiku
+money	lv	byn	100000	simts tūkstoši Baltkrievijas rubļi un nulle kapeiku
+money	lv	byn	1000000	viens miljons Baltkrievijas rubļi un nulle kapeiku
+money	lv	byn	2000000	divi miljoni Baltkrievijas rubļi un nulle kapeiku
+money	lv	byn	1000000000	viens miljards Baltkrievijas rubļi un nulle kapeiku
+money	lv	byn	123.45	simts divdesmit trīs Baltkrievijas rubļi un četrdesmit pieci kapeikas
+money	lv	byn	-1	mīnus viens Baltkrievijas rublis un nulle kapeiku
+money	lv	byn	-2	mīnus divi Baltkrievijas rubļi un nulle kapeiku
+money	lv	byn	-41.5	mīnus četrdesmit viens Baltkrievijas rublis un piecdesmit kapeikas
+money	lv	byn	-1000	mīnus viens tūkstotis Baltkrievijas rubļi un nulle kapeiku
+money	lv	byn	1.999	divi Baltkrievijas rubļi un nulle kapeiku
+money	lv	byn	123.456	simts divdesmit trīs Baltkrievijas rubļi un četrdesmit seši kapeikas
+money	lv	byn	1.005	viens Baltkrievijas rublis un viena kapeika
+money	lv	ars	0	nulle Argentīnas peso un nulle centavo
+money	lv	ars	0.01	nulle Argentīnas peso un viens centavo
+money	lv	ars	0.02	nulle Argentīnas peso un divi centavo
+money	lv	ars	1	viens Argentīnas peso un nulle centavo
+money	lv	ars	1.01	viens Argentīnas peso un viens centavo
+money	lv	ars	1.02	viens Argentīnas peso un divi centavo
+money	lv	ars	2	divi Argentīnas peso un nulle centavo
+money	lv	ars	2.02	divi Argentīnas peso un divi centavo
+money	lv	ars	3	trīs Argentīnas peso un nulle centavo
+money	lv	ars	5	pieci Argentīnas peso un nulle centavo
+money	lv	ars	11	vienpadsmit Argentīnas peso un nulle centavo
+money	lv	ars	21	divdesmit viens Argentīnas peso un nulle centavo
+money	lv	ars	22	divdesmit divi Argentīnas peso un nulle centavo
+money	lv	ars	42	četrdesmit divi Argentīnas peso un nulle centavo
+money	lv	ars	100	simts Argentīnas peso un nulle centavo
+money	lv	ars	101	simts viens Argentīnas peso un nulle centavo
+money	lv	ars	121	simts divdesmit viens Argentīnas peso un nulle centavo
+money	lv	ars	999	deviņi simti deviņdesmit deviņi Argentīnas peso un nulle centavo
+money	lv	ars	1000	viens tūkstotis Argentīnas peso un nulle centavo
+money	lv	ars	1001	viens tūkstotis viens Argentīnas peso un nulle centavo
+money	lv	ars	2000	divi tūkstoši Argentīnas peso un nulle centavo
+money	lv	ars	2001	divi tūkstoši viens Argentīnas peso un nulle centavo
+money	lv	ars	5000	pieci tūkstoši Argentīnas peso un nulle centavo
+money	lv	ars	21000	divdesmit viens tūkstoši Argentīnas peso un nulle centavo
+money	lv	ars	22000	divdesmit divi tūkstoši Argentīnas peso un nulle centavo
+money	lv	ars	41000	četrdesmit viens tūkstoši Argentīnas peso un nulle centavo
+money	lv	ars	42000	četrdesmit divi tūkstoši Argentīnas peso un nulle centavo
+money	lv	ars	100000	simts tūkstoši Argentīnas peso un nulle centavo
+money	lv	ars	1000000	viens miljons Argentīnas peso un nulle centavo
+money	lv	ars	2000000	divi miljoni Argentīnas peso un nulle centavo
+money	lv	ars	1000000000	viens miljards Argentīnas peso un nulle centavo
+money	lv	ars	123.45	simts divdesmit trīs Argentīnas peso un četrdesmit pieci centavo
+money	lv	ars	-1	mīnus viens Argentīnas peso un nulle centavo
+money	lv	ars	-2	mīnus divi Argentīnas peso un nulle centavo
+money	lv	ars	-41.5	mīnus četrdesmit viens Argentīnas peso un piecdesmit centavo
+money	lv	ars	-1000	mīnus viens tūkstotis Argentīnas peso un nulle centavo
+money	lv	ars	1.999	divi Argentīnas peso un nulle centavo
+money	lv	ars	123.456	simts divdesmit trīs Argentīnas peso un četrdesmit seši centavo
+money	lv	ars	1.005	viens Argentīnas peso un viens centavo
+money	lv	brl	0	nulle Brazīlijas reālu un nulle centavo
+money	lv	brl	0.01	nulle Brazīlijas reālu un viens centavo
+money	lv	brl	0.02	nulle Brazīlijas reālu un divi centavo
+money	lv	brl	1	viens Brazīlijas reāls un nulle centavo
+money	lv	brl	1.01	viens Brazīlijas reāls un viens centavo
+money	lv	brl	1.02	viens Brazīlijas reāls un divi centavo
+money	lv	brl	2	divi Brazīlijas reāli un nulle centavo
+money	lv	brl	2.02	divi Brazīlijas reāli un divi centavo
+money	lv	brl	3	trīs Brazīlijas reāli un nulle centavo
+money	lv	brl	5	pieci Brazīlijas reāli un nulle centavo
+money	lv	brl	11	vienpadsmit Brazīlijas reāli un nulle centavo
+money	lv	brl	21	divdesmit viens Brazīlijas reāls un nulle centavo
+money	lv	brl	22	divdesmit divi Brazīlijas reāli un nulle centavo
+money	lv	brl	42	četrdesmit divi Brazīlijas reāli un nulle centavo
+money	lv	brl	100	simts Brazīlijas reāli un nulle centavo
+money	lv	brl	101	simts viens Brazīlijas reāls un nulle centavo
+money	lv	brl	121	simts divdesmit viens Brazīlijas reāls un nulle centavo
+money	lv	brl	999	deviņi simti deviņdesmit deviņi Brazīlijas reāli un nulle centavo
+money	lv	brl	1000	viens tūkstotis Brazīlijas reāli un nulle centavo
+money	lv	brl	1001	viens tūkstotis viens Brazīlijas reāls un nulle centavo
+money	lv	brl	2000	divi tūkstoši Brazīlijas reāli un nulle centavo
+money	lv	brl	2001	divi tūkstoši viens Brazīlijas reāls un nulle centavo
+money	lv	brl	5000	pieci tūkstoši Brazīlijas reāli un nulle centavo
+money	lv	brl	21000	divdesmit viens tūkstoši Brazīlijas reāli un nulle centavo
+money	lv	brl	22000	divdesmit divi tūkstoši Brazīlijas reāli un nulle centavo
+money	lv	brl	41000	četrdesmit viens tūkstoši Brazīlijas reāli un nulle centavo
+money	lv	brl	42000	četrdesmit divi tūkstoši Brazīlijas reāli un nulle centavo
+money	lv	brl	100000	simts tūkstoši Brazīlijas reāli un nulle centavo
+money	lv	brl	1000000	viens miljons Brazīlijas reāli un nulle centavo
+money	lv	brl	2000000	divi miljoni Brazīlijas reāli un nulle centavo
+money	lv	brl	1000000000	viens miljards Brazīlijas reāli un nulle centavo
+money	lv	brl	123.45	simts divdesmit trīs Brazīlijas reāli un četrdesmit pieci centavo
+money	lv	brl	-1	mīnus viens Brazīlijas reāls un nulle centavo
+money	lv	brl	-2	mīnus divi Brazīlijas reāli un nulle centavo
+money	lv	brl	-41.5	mīnus četrdesmit viens Brazīlijas reāls un piecdesmit centavo
+money	lv	brl	-1000	mīnus viens tūkstotis Brazīlijas reāli un nulle centavo
+money	lv	brl	1.999	divi Brazīlijas reāli un nulle centavo
+money	lv	brl	123.456	simts divdesmit trīs Brazīlijas reāli un četrdesmit seši centavo
+money	lv	brl	1.005	viens Brazīlijas reāls un viens centavo
+money	lv	uzs	0	nulle Uzbekistānas sumu un nulle tijinu
+money	lv	uzs	0.01	nulle Uzbekistānas sumu un viens tijins
+money	lv	uzs	0.02	nulle Uzbekistānas sumu un divi tijini
+money	lv	uzs	1	viens Uzbekistānas sums un nulle tijinu
+money	lv	uzs	1.01	viens Uzbekistānas sums un viens tijins
+money	lv	uzs	1.02	viens Uzbekistānas sums un divi tijini
+money	lv	uzs	2	divi Uzbekistānas sumi un nulle tijinu
+money	lv	uzs	2.02	divi Uzbekistānas sumi un divi tijini
+money	lv	uzs	3	trīs Uzbekistānas sumi un nulle tijinu
+money	lv	uzs	5	pieci Uzbekistānas sumi un nulle tijinu
+money	lv	uzs	11	vienpadsmit Uzbekistānas sumi un nulle tijinu
+money	lv	uzs	21	divdesmit viens Uzbekistānas sums un nulle tijinu
+money	lv	uzs	22	divdesmit divi Uzbekistānas sumi un nulle tijinu
+money	lv	uzs	42	četrdesmit divi Uzbekistānas sumi un nulle tijinu
+money	lv	uzs	100	simts Uzbekistānas sumi un nulle tijinu
+money	lv	uzs	101	simts viens Uzbekistānas sums un nulle tijinu
+money	lv	uzs	121	simts divdesmit viens Uzbekistānas sums un nulle tijinu
+money	lv	uzs	999	deviņi simti deviņdesmit deviņi Uzbekistānas sumi un nulle tijinu
+money	lv	uzs	1000	viens tūkstotis Uzbekistānas sumi un nulle tijinu
+money	lv	uzs	1001	viens tūkstotis viens Uzbekistānas sums un nulle tijinu
+money	lv	uzs	2000	divi tūkstoši Uzbekistānas sumi un nulle tijinu
+money	lv	uzs	2001	divi tūkstoši viens Uzbekistānas sums un nulle tijinu
+money	lv	uzs	5000	pieci tūkstoši Uzbekistānas sumi un nulle tijinu
+money	lv	uzs	21000	divdesmit viens tūkstoši Uzbekistānas sumi un nulle tijinu
+money	lv	uzs	22000	divdesmit divi tūkstoši Uzbekistānas sumi un nulle tijinu
+money	lv	uzs	41000	četrdesmit viens tūkstoši Uzbekistānas sumi un nulle tijinu
+money	lv	uzs	42000	četrdesmit divi tūkstoši Uzbekistānas sumi un nulle tijinu
+money	lv	uzs	100000	simts tūkstoši Uzbekistānas sumi un nulle tijinu
+money	lv	uzs	1000000	viens miljons Uzbekistānas sumi un nulle tijinu
+money	lv	uzs	2000000	divi miljoni Uzbekistānas sumi un nulle tijinu
+money	lv	uzs	1000000000	viens miljards Uzbekistānas sumi un nulle tijinu
+money	lv	uzs	123.45	simts divdesmit trīs Uzbekistānas sumi un četrdesmit pieci tijini
+money	lv	uzs	-1	mīnus viens Uzbekistānas sums un nulle tijinu
+money	lv	uzs	-2	mīnus divi Uzbekistānas sumi un nulle tijinu
+money	lv	uzs	-41.5	mīnus četrdesmit viens Uzbekistānas sums un piecdesmit tijini
+money	lv	uzs	-1000	mīnus viens tūkstotis Uzbekistānas sumi un nulle tijinu
+money	lv	uzs	1.999	divi Uzbekistānas sumi un nulle tijinu
+money	lv	uzs	123.456	simts divdesmit trīs Uzbekistānas sumi un četrdesmit seši tijini
+money	lv	uzs	1.005	viens Uzbekistānas sums un viens tijins
 money	lv	gbp	0	nulle sterliņu mārciņu un nulle pensu
 money	lv	gbp	0.01	nulle sterliņu mārciņu un viens penss
 money	lv	gbp	0.02	nulle sterliņu mārciņu un divi pensi

--- a/src/Nut/TextConverters/LatvianConverter.cs
+++ b/src/Nut/TextConverters/LatvianConverter.cs
@@ -170,6 +170,102 @@ namespace Nut.TextConverters
               Names = new[] { "penss", "pensi", "pensu" }
             }
           };
+        case Currency.ARS:
+          return new CurrencyModel
+          {
+            Currency = currency,
+            Names = new[] { "Argentīnas peso", "Argentīnas peso", "Argentīnas peso" },
+            Gender = GenderGroup.Masculine,
+            SubUnitCurrency = new BaseCurrencyModel
+            {
+              Gender = GenderGroup.Masculine,
+              Names = new[] { "centavo", "centavo", "centavo" }
+            }
+          };
+        case Currency.BGN:
+          return new CurrencyModel
+          {
+            Currency = currency,
+            Names = new[] { "Bulgārijas leva", "Bulgārijas levas", "Bulgārijas levu" },
+            Gender = GenderGroup.Feminine,
+            SubUnitCurrency = new BaseCurrencyModel
+            {
+              Gender = GenderGroup.Feminine,
+              Names = new[] { "stotinka", "stotinkas", "stotinku" }
+            }
+          };
+        case Currency.BRL:
+          return new CurrencyModel
+          {
+            Currency = currency,
+            Names = new[] { "Brazīlijas reāls", "Brazīlijas reāli", "Brazīlijas reālu" },
+            Gender = GenderGroup.Masculine,
+            SubUnitCurrency = new BaseCurrencyModel
+            {
+              Gender = GenderGroup.Masculine,
+              Names = new[] { "centavo", "centavo", "centavo" }
+            }
+          };
+        case Currency.BYN:
+          return new CurrencyModel
+          {
+            Currency = currency,
+            Names = new[] { "Baltkrievijas rublis", "Baltkrievijas rubļi", "Baltkrievijas rubļu" },
+            Gender = GenderGroup.Masculine,
+            SubUnitCurrency = new BaseCurrencyModel
+            {
+              Gender = GenderGroup.Feminine,
+              Names = new[] { "kapeika", "kapeikas", "kapeiku" }
+            }
+          };
+        case Currency.ETB:
+          return new CurrencyModel
+          {
+            Currency = currency,
+            Names = new[] { "Etiopijas birs", "Etiopijas biri", "Etiopijas biru" },
+            Gender = GenderGroup.Masculine,
+            SubUnitCurrency = new BaseCurrencyModel
+            {
+              Gender = GenderGroup.Masculine,
+              Names = new[] { "santīms", "santīmi", "santīmu" }
+            }
+          };
+        case Currency.TRY:
+          return new CurrencyModel
+          {
+            Currency = currency,
+            Names = new[] { "Turcijas lira", "Turcijas liras", "Turcijas liru" },
+            Gender = GenderGroup.Feminine,
+            SubUnitCurrency = new BaseCurrencyModel
+            {
+              Gender = GenderGroup.Masculine,
+              Names = new[] { "kuruss", "kurusi", "kurusu" }
+            }
+          };
+        case Currency.UAH:
+          return new CurrencyModel
+          {
+            Currency = currency,
+            Names = new[] { "Ukrainas grivna", "Ukrainas grivnas", "Ukrainas grivnu" },
+            Gender = GenderGroup.Feminine,
+            SubUnitCurrency = new BaseCurrencyModel
+            {
+              Gender = GenderGroup.Feminine,
+              Names = new[] { "kapeika", "kapeikas", "kapeiku" }
+            }
+          };
+        case Currency.UZS:
+          return new CurrencyModel
+          {
+            Currency = currency,
+            Names = new[] { "Uzbekistānas sums", "Uzbekistānas sumi", "Uzbekistānas sumu" },
+            Gender = GenderGroup.Masculine,
+            SubUnitCurrency = new BaseCurrencyModel
+            {
+              Gender = GenderGroup.Masculine,
+              Names = new[] { "tijins", "tijini", "tijinu" }
+            }
+          };
         case Currency.USD:
           return new CurrencyModel
           {


### PR DESCRIPTION
Latvian shipped with five currencies; every other language carries thirteen. Additive.

```
viena Turcijas lira un nulle kurusu
viens Baltkrievijas rublis un nulle kapeiku
divi Brazīlijas reāli un nulle centavo
```

Each follows the pattern Latvian uses for a foreign currency — country in the genitive, then the unit — with the three inflected forms the converter needs and the right gender, so `lira` and `grivna` take `viena` while `rublis` and `reāls` take `viens`.

## Parity is now complete

The only combinations still unsupported are **Amharic's four** — ARS, BRL, GBP, UZS. I am not writing Amharic currency names, and with #60 in place those fail with a clear message rather than a blank.

## Verification

- Modified rows in the snapshot: zero. Only the previous `NotSupportedException` rows became text.
- 588 tests.

## What I would want checked

The names are consistently formed and follow the language's pattern, but I did not look each one up. Worth a native speaker's eye:

- `Turcijas lira` / `kuruss` — the Turkish sub-unit especially
- `Bulgārijas leva` — whether the unit is feminine `leva` or masculine `levs` in Latvian usage
- `Uzbekistānas sums` / `tijins`
- Whether `peso` and `centavo` stay uninflected, which is how I have them

This is the same caveat as the other parity PRs: written from the pattern, not from a dictionary.