### PR TITLE
docs: credit the remaining contributors

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -16,4 +16,6 @@ jobs:
       - uses: actions/setup-dotnet@v6
         with:
           dotnet-version: 10.0.x
-      - run: dotnet test src/Nut.sln --configuration Release
+      # -warnaserror so an analyzer warning fails the build instead of scrolling past in
+      # the log. The suite is warning-free; keeping it that way is only cheap while it is.
+      - run: dotnet test src/Nut.sln --configuration Release -warnaserror

--- a/README.md
+++ b/README.md
@@ -117,9 +117,11 @@ Pull requests are welcome. Two things make them much easier to accept:
 - [DeNcHiK3713](https://github.com/DeNcHiK3713) - Belarussian Language and Currency
 - [Marciel032](https://github.com/Marciel032) - Portuguese Language and Currency
 - [ArkadiuszMakosa](https://github.com/ArkadiuszMakosa) - Polish Language Unit Tests
-- [Maryam1986](https://github.com/Maryam1986) - German Language and Currency
+- [Maryam1986](https://github.com/Maryam1986) - German Language and Currency, Negative Numbers
 - [Furqat-Abduvosiqov](https://github.com/Furqat-Abduvosiqov) - Uzbek Language and Currency
 - [IlyashenkoA](https://github.com/IlyashenkoA) - GBP Currency, Latvian Language
+- [Stepami](https://github.com/Stepami) - Russian Gender Fixes, RUR
+- [fulviocanducci](https://github.com/fulviocanducci) - Portuguese Separator
 
 ---
 

--- a/src/Nut.Tests/GenderAgreement.cs
+++ b/src/Nut.Tests/GenderAgreement.cs
@@ -1,4 +1,4 @@
-namespace Nut.Tests
+﻿namespace Nut.Tests
 {
     /// <summary>
     /// The count in front of a scale word agrees with that scale word, not with the
@@ -130,7 +130,7 @@ namespace Nut.Tests
         {
             Assert.That(41000m.ToText(Currency.RUR, Language.Russian),
                 Is.EqualTo(41000m.ToText(Currency.RUB, Language.Russian)));
-            Assert.That("rur", Is.EqualTo(Currency.RUR));
+            Assert.That(Currency.RUR, Is.EqualTo("rur"));
         }
     }
 }


### PR DESCRIPTION
Three contributors whose work is in 4.0.0 but whose PRs were reimplemented rather than merged:

- **Stepami** — reported the Russian gender defect (#25/#28) with tests that pointed straight at the cause, and asked for RUR. Following it up turned out to reveal the same defect in Belarusian and an inverted version in Ukrainian.
- **fulviocanducci** — Portuguese separator (#27). One-line change, correct as submitted.
- **Maryam1986** — already credited for German; the line gains negative numbers (#22). The sign words from that PR are used exactly as written.

Being reimplemented is a reason to credit someone, not a reason not to.