### PR TITLE
refactor: rename Extentions to Extensions, seal BulgarianConverter

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -123,6 +123,15 @@ assert on that text, review the tables below before taking this release.
 
 ### Changed
 
+- **`Nut.Extentions` is renamed to `Nut.Extensions`**, correcting a long-standing typo in
+  the class name. Extension-method calls — `number.ToText("en")` — are unaffected, since
+  they never name the class. Only code calling it explicitly, such as
+  `Nut.Extentions.ToText(...)`, needs updating.
+
+- **`BulgarianConverter` is now `sealed`**, like the other thirteen converters. Word
+  tables are shared between instances, so a subclass writing to one would corrupt the
+  singleton; sealing enforces what a comment previously only asked for.
+
 - **An unsupported language or currency now throws `NotSupportedException`** instead of
   returning an empty string. This library writes amounts onto invoices and cheques, where
   a blank in the amount field is worse than a failed call: nothing surfaces it until the

--- a/README.md
+++ b/README.md
@@ -19,7 +19,7 @@ Money To Text Converter
 
 **Unsupported input:** asking for a language or currency that is not supported throws
 `NotSupportedException` rather than returning an empty string — a blank amount field is
-harder to notice than an exception. `Extentions.SupportedLanguages` lists what is accepted.
+harder to notice than an exception. `Extensions.SupportedLanguages` lists what is accepted.
 
 **Cheque form:** `Options.SubUnitFormat = SubUnitFormat.Fraction` writes the fractional
 part as `and 50/100` instead of `fifty cents`, which is how amounts are commonly written

--- a/src/Nut.Tests/LanguageResolution.cs
+++ b/src/Nut.Tests/LanguageResolution.cs
@@ -101,7 +101,7 @@ namespace Nut.Tests
         [Test]
         public void SupportedLanguagesIsDiscoverable()
         {
-            Assert.That(Extentions.SupportedLanguages, Contains.Item("en").And.Contains("en-GB").And.Contains("lv"));
+            Assert.That(Extensions.SupportedLanguages, Contains.Item("en").And.Contains("en-GB").And.Contains("lv"));
         }
     }
 }

--- a/src/Nut/Extensions.cs
+++ b/src/Nut/Extensions.cs
@@ -6,7 +6,7 @@ using System.Linq;
 
 namespace Nut
 {
-    public static class Extentions
+    public static class Extensions
     {
         /// <summary>
         /// Language and culture codes to converters. Matching ignores case, so "en-US",

--- a/src/Nut/TextConverters/BulgarianConverter.cs
+++ b/src/Nut/TextConverters/BulgarianConverter.cs
@@ -4,7 +4,7 @@ using Nut.Models;
 
 namespace Nut.TextConverters
 {
-    public class BulgarianConverter : BaseConverter
+    public sealed class BulgarianConverter : BaseConverter
     {
         private static Lazy<BulgarianConverter> Lazy = new Lazy<BulgarianConverter>(() => new BulgarianConverter());
         public static BulgarianConverter Instance => Lazy.Value;
@@ -12,7 +12,7 @@ namespace Nut.TextConverters
 
         protected override string NegativeSign => "минус";
 
-        protected int textType = 0;
+        private int textType;
 
         public BulgarianConverter()
         {


### PR DESCRIPTION
**Breaking**, narrowly. 4.0.0 is the place for it.

## The rename

`Nut.Extentions` has been misspelled since 2014.

**Who is affected:** almost nobody. Extension-method calls never name the class:

```csharp
number.ToText("en")          // unaffected — needs only `using Nut;`
Nut.Extentions.ToText(...)   // breaks — but nobody calls an extension class this way
```

**Why now:** `SupportedLanguages` was added to it yesterday. That is a static member, reached through the class name, so the typo had begun spreading into new API. Every week it waits, more attaches to it.

**Why no `[Obsolete]` bridge:** two classes carrying the same extension methods make every call ambiguous — `CS0121` — so the bridge breaks precisely the callers it exists to protect. A bridge of non-extension forwarding methods is possible but costs two classes of maintenance for a rename that affects a handful of call sites.

## The seal

`BulgarianConverter` was the only converter not `sealed`. That is no longer just inconsistency: word tables are shared between instances since the per-conversion pattern landed, so a subclass writing to one would corrupt the singleton. `BaseConverter`'s comment asks callers not to; `sealed` enforces it.

Its `textType` field drops from `protected` to `private` in the same move — nothing outside can derive now.

I checked: nothing in the repo derives from it.

## Verification

- Snapshot unchanged — no output moves.
- 588 tests, `-warnaserror`.