### PR TITLE
fix: what the second review found, and two things it argued me out of

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -131,6 +131,19 @@ assert on that text, review the tables below before taking this release.
 - **Portuguese** joins the two parts of an amount with `e` rather than `com`
   ([#27](https://github.com/emrahyumuk/NUT-number-to-text/pull/27)).
 
+- **Portuguese named the wrong country's currency for `UZS`.** Priberam keeps `som` (the
+  Kyrgyz som, KGS) and `sum` (the Uzbek sum, UZS) apart, and the library used the first for
+  the second. `soms` is not a possible Portuguese plural either. It reads
+  `sum usbeque` / `sumes usbeques` now.
+
+- **French `réals brésiliens` is `réaux brésiliens`.** Académie française gives `réal`,
+  plural `réaux`; the OQLF writes the same. `réals` is in no dictionary.
+
+- **`PortugueseConverter.CultureName` returned `es-ES`.** A copy-paste from the first
+  commit that added the converter. Casing is unaffected, both being Latin script, but the
+  culture is what the unsupported-currency message names, and that message is read now
+  that it is thrown rather than swallowed.
+
 - **Polish and Ukrainian no longer capitalise every numeral.** Their word tables were stored
   capitalised, so `105.50 PLN` read `Sto Pięć złotych Pięćdziesiąt groszy` — capitals in the
   middle of a phrase that neither language uses, and inconsistent even with itself, since
@@ -185,6 +198,11 @@ assert on that text, review the tables below before taking this release.
   their catch the way this entry recommends still crashed. Leaving the whole part as digits
   with `MainUnitNotConvertedToText` skipped the conversion, and with it the check.
 
+  It also runs again after rounding, which can carry an in-range amount over the limit:
+  `999999999999.995` used to throw on the default path and render as
+  `1000000000000 dollars` with the whole part left as digits. One input, two answers,
+  depending on the output format.
+
 - **Neuter gender.** `GenderGroup` had only `None`, `Feminine` and `Masculine`, so a
   neuter currency name fell through to the masculine numeral: `един евро`, `один песо`.
   Bulgarian marks all three (`един` / `една` / `едно`), and евро and пени are neuter;
@@ -211,7 +229,13 @@ assert on that text, review the tables below before taking this release.
 
   The scale words take that same rule, and they are masculine nouns, so the count in front
   of one agrees with the scale word rather than with the currency: `viens tūkstotis
-  sterliņu mārciņas`, not `viena`, and `divdesmit viens tūkstotis`, not `tūkstoši`.
+  sterliņu mārciņu`, not `viena`, and `divdesmit viens tūkstotis`, not `tūkstoši`.
+
+  They also govern the genitive plural of what they count: `viens tūkstotis ASV dolāru`,
+  not `dolāri`. This applies wherever the amount ends on one of them, so `simts`,
+  `divi simti`, `viens tūkstotis simts` and `viens miljons` all take it, while `desmit`
+  does not decline and governs nothing. Round amounts are the ones a document is most
+  likely to carry, so the first cut of this converter was wrong in the worst place.
 
 - **Uzbek (Latin script)** and the Uzbek som (`UZS`), from
   [#23](https://github.com/emrahyumuk/NUT-number-to-text/pull/23). The number system builds

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -241,6 +241,12 @@ assert on that text, review the tables below before taking this release.
   [#23](https://github.com/emrahyumuk/NUT-number-to-text/pull/23). The number system builds
   from twenty-two basic words and behaves like Turkish: no "bir" before *yuz* or *ming*.
 
+  Uzbek covers the three currencies #23 supplied — `UZS`, `USD` and `RUB` — and no others.
+  The rest were filled in for parity and their sub-unit names are in no Uzbek source: five
+  ended up as `tiyin`, which is the som's own sub-unit, not the Turkish lira's. #23 had the
+  rouble right, with `kopeyka`, and the parity pass wrote over it. Anything else raises
+  `NotSupportedException` until someone who reads Uzbek fills it in.
+
 - `Extensions.SupportedLanguages`, listing every language and culture string accepted.
 
 - `Options.SubUnitFormat`, an enum choosing how the fractional part is written: `Words`
@@ -249,11 +255,12 @@ assert on that text, review the tables below before taking this release.
   `Digits`; setting `SubUnitFormat` explicitly overrides it, including when what you set is
   `Words`.
 
-  `Fraction` is available in English, Spanish, Portuguese, Bulgarian, Latvian and Amharic —
-  the languages that join the two parts of an amount with a word. Writing the sub-unit over
-  a hundred is an anglophone cheque convention rather than a rule of any language, and the
-  other eight have no wording for it here, so asking for it there raises
-  `NotSupportedException`.
+  `Fraction` is **English only**. Writing the sub-unit over a hundred is an anglophone
+  cheque convention rather than a rule of any language. It first fell back to the English
+  *and* wherever a converter left the unit separator as a plain space, which reached nine of
+  the fourteen; deriving the word from the unit separator instead covered five more, but
+  having a word for "and" is not evidence that a country writes 50/100 on a cheque. Asking
+  for the form in any other language raises `NotSupportedException`.
 
 - `Options.SubUnitTruncated`, for callers who need extra decimals dropped rather than
   carried: `1.999` reads as "one dollar ninety-nine cents". Rounding remains the default.

--- a/README.md
+++ b/README.md
@@ -121,7 +121,20 @@ Set `SubUnitTruncated` to cut the digits instead.
 raises `NotSupportedException` naming what was asked for. It does not return an empty
 string: a blank amount field on a document is not noticed until the document has gone out.
 
+**Ukrainian paper payment instructions** require the amount in words to start with a
+capital letter — NBU Board Resolution 29.07.2022 №163, Annex, field 4. Pass
+`MainUnitFirstCharUpper` when printing one. The same resolution says the field is left
+empty on electronic instructions.
+
+```csharp
+var options = new Options { MainUnitFirstCharUpper = true };
+105.50m.ToText(Currency.UAH, Language.Ukrainian, options);
+// Сто п'ять гривень п'ятдесят копійок
+```
+
 **Range.** Magnitudes below one trillion. Beyond that raises `ArgumentOutOfRangeException`.
+Rounding counts: an amount that crosses the limit only after being rounded to the sub-unit
+raises it too.
 
 **Thread safety.** Conversions are independent and safe to run in parallel.
 

--- a/README.md
+++ b/README.md
@@ -54,8 +54,9 @@ resolve, but the codes above are the ones `CultureInfo` hands you.
 
 Also accepted: `TL` for `TRY`, `RUR` for `RUB`.
 
-Every language covers every currency, except Amharic, which is missing `ARS`, `BRL`, `GBP`
-and `UZS`.
+Every language covers every currency, with two exceptions. Amharic is missing `ARS`, `BRL`,
+`GBP` and `UZS`. Uzbek covers only `UZS`, `USD` and `RUB` — the three its contributor
+supplied. A combination a language does not cover raises `NotSupportedException`.
 
 ```csharp
 2575.50m.ToText(Currency.EUR, Language.German);   // zweitausendfünfhundertfünfundsiebzig Euro fünfzig Cent
@@ -90,13 +91,11 @@ new Options { SubUnitFormat = SubUnitFormat.Fraction }
 ```
 
 Zero is written as `00/100` rather than dropped, so nothing can be added to the amount
-afterwards. Languages that join the two parts with a word keep it: *con 50/100* in Spanish,
-*un 50/100* in Latvian.
+afterwards.
 
 Writing the sub-unit over a hundred is an anglophone cheque convention rather than a rule
-of any language, so it is only available where there is a word to join the two parts with:
-English, Spanish, Portuguese, Bulgarian, Latvian and Amharic. Asking for it in one of the
-other eight raises `NotSupportedException` instead of borrowing the English *and*.
+of any language, so **English is the only language it is available in**. Asking for it in
+any other raises `NotSupportedException` rather than borrowing the English *and*.
 
 ## Behaviour worth knowing
 

--- a/src/Nut.Tests/LatvianNumerals.cs
+++ b/src/Nut.Tests/LatvianNumerals.cs
@@ -29,7 +29,7 @@ namespace Nut.Tests
         [TestCase(1, "viens eiro un nulle centu")]
         [TestCase(2, "divi eiro un nulle centu")]
         [TestCase(21, "divdesmit viens eiro un nulle centu")]
-        [TestCase(1000, "viens tūkstotis eiro un nulle centu")]
+        [TestCase(1000, "viens tūkstotis eiro un nulle centu")]  // eiro does not decline
         [TestCase(1234.56, "viens tūkstotis divi simti trīsdesmit četri eiro un piecdesmit seši centi")]
         public void Euro(decimal amount, string expected)
         {
@@ -72,9 +72,50 @@ namespace Nut.Tests
         public void ScaleWordsStayMasculineAndInflect(decimal amount, string count)
         {
             Assert.That(amount.ToText(Currency.GBP, Language.Latvian),
-                Does.StartWith(count + " sterliņu mārciņas"));
+                Does.StartWith(count + " sterliņu mārciņu"));
             Assert.That(amount.ToText(Currency.USD, Language.Latvian),
-                Does.StartWith(count + " ASV dolāri"));
+                Does.StartWith(count + " ASV dolāru"));
+        }
+
+        /// <summary>
+        /// The declinable scale words — simts, tūkstotis, miljons, miljards — govern the
+        /// genitive plural of what they count. This test previously pinned the nominative,
+        /// which is wrong on exactly the amounts a document is most likely to carry.
+        /// <para>
+        /// Source: uzdevumi.lv, "Aiz lokāmajām formām desmits, simts, tūkstotis, miljons,
+        /// miljards pieņemts lietot lietvārdu daudzskaitļa ģenitīvā"; and
+        /// valodaskonsultacijas.lv, "pieci tūkstoši cilvēku", "četri simti iedzīvotāju".
+        /// </para>
+        /// </summary>
+        [TestCase(100, "simts ASV dolāru")]
+        [TestCase(200, "divi simti ASV dolāru")]
+        [TestCase(1000, "viens tūkstotis ASV dolāru")]
+        [TestCase(1100, "viens tūkstotis simts ASV dolāru")]
+        [TestCase(1200, "viens tūkstotis divi simti ASV dolāru")]
+        [TestCase(2000, "divi tūkstoši ASV dolāru")]
+        [TestCase(21000, "divdesmit viens tūkstotis ASV dolāru")]
+        [TestCase(100000, "simts tūkstoši ASV dolāru")]
+        [TestCase(1000000, "viens miljons ASV dolāru")]
+        [TestCase(1000000000, "viens miljards ASV dolāru")]
+        public void ScaleWordsGovernTheGenitivePlural(decimal amount, string expected)
+        {
+            Assert.That(amount.ToText(Currency.USD, Language.Latvian),
+                Is.EqualTo(expected + " un nulle centu"));
+        }
+
+        /// <summary>
+        /// Ten does not decline, so it governs nothing and the noun stays nominative. This
+        /// is the boundary the "ends in two zeros" test has to get right.
+        /// </summary>
+        [TestCase(10, "desmit ASV dolāri")]
+        [TestCase(110, "simts desmit ASV dolāri")]
+        [TestCase(120, "simts divdesmit ASV dolāri")]
+        [TestCase(101, "simts viens ASV dolārs")]
+        [TestCase(1234, "viens tūkstotis divi simti trīsdesmit četri ASV dolāri")]
+        public void TenDoesNotGovernTheGenitive(decimal amount, string expected)
+        {
+            Assert.That(amount.ToText(Currency.USD, Language.Latvian),
+                Is.EqualTo(expected + " un nulle centu"));
         }
 
         [Test]

--- a/src/Nut.Tests/NumberLimit.cs
+++ b/src/Nut.Tests/NumberLimit.cs
@@ -54,6 +54,37 @@ namespace Nut.Tests
                 Throws.InstanceOf<ArgumentOutOfRangeException>());
         }
 
+        /// <summary>
+        /// Rounding can carry an in-range amount over the limit, and the answer must not
+        /// depend on which output format is asked for. Checking only on the way in let
+        /// 999999999999.995 render as "1000000000000 dollars" with the whole part left as
+        /// digits, while the same input threw on the default path.
+        /// </summary>
+        [Test]
+        public void RoundingCannotCarryPastTheLimit()
+        {
+            const decimal justUnder = 999999999999.995m;
+
+            Assert.Multiple(() =>
+            {
+                Assert.That(() => justUnder.ToText(Currency.USD, Language.English),
+                    Throws.InstanceOf<ArgumentOutOfRangeException>());
+                Assert.That(() => justUnder.ToText(Currency.USD, Language.English,
+                        new Options { MainUnitNotConvertedToText = true }),
+                    Throws.InstanceOf<ArgumentOutOfRangeException>());
+                Assert.That(() => justUnder.ToText(Currency.USD, Language.English,
+                        new Options { SubUnitFormat = SubUnitFormat.Fraction }),
+                    Throws.InstanceOf<ArgumentOutOfRangeException>());
+
+                // Truncating drops the digits instead of carrying them, so it stays in range.
+                Assert.That(() => justUnder.ToText(Currency.USD, Language.English,
+                        new Options { SubUnitTruncated = true }),
+                    Throws.Nothing);
+                Assert.That(() => 999999999999.994m.ToText(Currency.USD, Language.English),
+                    Throws.Nothing);
+            });
+        }
+
         /// <summary>The message should say what the range is, not just that something failed.</summary>
         [Test]
         public void TheMessageStatesTheRange()

--- a/src/Nut.Tests/PoundSterling.cs
+++ b/src/Nut.Tests/PoundSterling.cs
@@ -14,7 +14,6 @@ namespace Nut.Tests
         [TestCase(Language.English, "one pound sterling one penny")]
         [TestCase(Language.Turkish, "bir sterlin bir peni")]
         [TestCase(Language.German, "ein Pfund Sterling ein Penny")]
-        [TestCase(Language.Uzbek, "bir funt sterling bir pens")]
         [TestCase(Language.Russian, "один фунт стерлингов один пенни")]
         [TestCase(Language.Belarusian, "адзін фунт стэрлінгаў адзін пені")]
         public void MasculineOrUninflected(string lang, string expected)

--- a/src/Nut.Tests/SubUnitFormats.cs
+++ b/src/Nut.Tests/SubUnitFormats.cs
@@ -63,23 +63,19 @@ namespace Nut.Tests
             Assert.That(text, Is.EqualTo("two thousand five hundred seventy-five dollars fifty cents"));
         }
 
-        /// <summary>Languages that already join the two parts with a word keep that word
-        /// rather than borrowing the English "and".</summary>
-        [TestCase(Language.Spanish, Currency.EUR, "ciento cinco euros con 50/100")]
-        [TestCase(Language.Portuguese, Currency.BRL, "cento e cinco reais e 50/100")]
-        [TestCase(Language.Bulgarian, Currency.BGN, "сто и пет лева и 50/100")]
-        [TestCase(Language.Latvian, Currency.EUR, "simts pieci eiro un 50/100")]
-        public void SeparatorFollowsTheLanguage(string lang, string currency, string expected)
-        {
-            Assert.That(105.50m.ToText(currency, lang, Fraction), Is.EqualTo(expected));
-        }
-
         /// <summary>
-        /// The rest have no separator to borrow, and the form is not theirs to begin with.
-        /// Falling back to the English "and" put it into nine of the fourteen — a Turkish
-        /// cheque read "yüz beş türk lirası and 50/100" — so ask for a form a language does
-        /// not have and you get told, rather than getting English in the amount field.
+        /// Every other language says so rather than producing something. The first cut
+        /// borrowed the English "and" wherever a converter left the unit separator as a
+        /// plain space, which reached nine of the fourteen: "yüz beş türk lirası and
+        /// 50/100". Deriving the word from the unit separator instead covered five more,
+        /// but having a word for "and" is not evidence that a country writes 50/100 on a
+        /// cheque, so those went too.
         /// </summary>
+        [TestCase(Language.Spanish, Currency.EUR)]
+        [TestCase(Language.Portuguese, Currency.BRL)]
+        [TestCase(Language.Bulgarian, Currency.BGN)]
+        [TestCase(Language.Latvian, Currency.EUR)]
+        [TestCase(Language.Amharic, Currency.ETB)]
         [TestCase(Language.French, Currency.EUR)]
         [TestCase(Language.German, Currency.EUR)]
         [TestCase(Language.Turkish, Currency.TRY)]
@@ -113,11 +109,6 @@ namespace Nut.Tests
             Assert.That(supported, Is.EquivalentTo(new[]
             {
                 Language.English, Culture.EnglishUS, Culture.EnglishGB,
-                Language.Spanish, Culture.Spanish,
-                Language.Portuguese, Culture.PortugueseBR,
-                Language.Bulgarian, Culture.Bulgarian,
-                Language.Latvian, Culture.Latvian,
-                Language.Amharic, Culture.EthiopianAM,
             }));
         }
 

--- a/src/Nut.Tests/behaviour-snapshot.tsv
+++ b/src/Nut.Tests/behaviour-snapshot.tsv
@@ -963,38 +963,38 @@ money	fr	brl	0.02	zéro réal brésilien deux centavos
 money	fr	brl	1	un réal brésilien zéro centavo
 money	fr	brl	1.01	un réal brésilien un centavo
 money	fr	brl	1.02	un réal brésilien deux centavos
-money	fr	brl	2	deux réals brésiliens zéro centavo
-money	fr	brl	2.02	deux réals brésiliens deux centavos
-money	fr	brl	3	trois réals brésiliens zéro centavo
-money	fr	brl	5	cinq réals brésiliens zéro centavo
-money	fr	brl	11	onze réals brésiliens zéro centavo
-money	fr	brl	21	vingt et un réals brésiliens zéro centavo
-money	fr	brl	22	vingt-deux réals brésiliens zéro centavo
-money	fr	brl	42	quarante-deux réals brésiliens zéro centavo
-money	fr	brl	100	cent réals brésiliens zéro centavo
-money	fr	brl	101	cent un réals brésiliens zéro centavo
-money	fr	brl	121	cent vingt et un réals brésiliens zéro centavo
-money	fr	brl	999	neuf cent quatre-vingt-dix-neuf réals brésiliens zéro centavo
-money	fr	brl	1000	mille réals brésiliens zéro centavo
-money	fr	brl	1001	mille un réals brésiliens zéro centavo
-money	fr	brl	2000	deux mille réals brésiliens zéro centavo
-money	fr	brl	2001	deux mille un réals brésiliens zéro centavo
-money	fr	brl	5000	cinq mille réals brésiliens zéro centavo
-money	fr	brl	21000	vingt et un mille réals brésiliens zéro centavo
-money	fr	brl	22000	vingt-deux mille réals brésiliens zéro centavo
-money	fr	brl	41000	quarante et un mille réals brésiliens zéro centavo
-money	fr	brl	42000	quarante-deux mille réals brésiliens zéro centavo
-money	fr	brl	100000	cent mille réals brésiliens zéro centavo
-money	fr	brl	1000000	un million réals brésiliens zéro centavo
-money	fr	brl	2000000	deux millions réals brésiliens zéro centavo
-money	fr	brl	1000000000	un milliard réals brésiliens zéro centavo
-money	fr	brl	123.45	cent vingt-trois réals brésiliens quarante-cinq centavos
+money	fr	brl	2	deux réaux brésiliens zéro centavo
+money	fr	brl	2.02	deux réaux brésiliens deux centavos
+money	fr	brl	3	trois réaux brésiliens zéro centavo
+money	fr	brl	5	cinq réaux brésiliens zéro centavo
+money	fr	brl	11	onze réaux brésiliens zéro centavo
+money	fr	brl	21	vingt et un réaux brésiliens zéro centavo
+money	fr	brl	22	vingt-deux réaux brésiliens zéro centavo
+money	fr	brl	42	quarante-deux réaux brésiliens zéro centavo
+money	fr	brl	100	cent réaux brésiliens zéro centavo
+money	fr	brl	101	cent un réaux brésiliens zéro centavo
+money	fr	brl	121	cent vingt et un réaux brésiliens zéro centavo
+money	fr	brl	999	neuf cent quatre-vingt-dix-neuf réaux brésiliens zéro centavo
+money	fr	brl	1000	mille réaux brésiliens zéro centavo
+money	fr	brl	1001	mille un réaux brésiliens zéro centavo
+money	fr	brl	2000	deux mille réaux brésiliens zéro centavo
+money	fr	brl	2001	deux mille un réaux brésiliens zéro centavo
+money	fr	brl	5000	cinq mille réaux brésiliens zéro centavo
+money	fr	brl	21000	vingt et un mille réaux brésiliens zéro centavo
+money	fr	brl	22000	vingt-deux mille réaux brésiliens zéro centavo
+money	fr	brl	41000	quarante et un mille réaux brésiliens zéro centavo
+money	fr	brl	42000	quarante-deux mille réaux brésiliens zéro centavo
+money	fr	brl	100000	cent mille réaux brésiliens zéro centavo
+money	fr	brl	1000000	un million réaux brésiliens zéro centavo
+money	fr	brl	2000000	deux millions réaux brésiliens zéro centavo
+money	fr	brl	1000000000	un milliard réaux brésiliens zéro centavo
+money	fr	brl	123.45	cent vingt-trois réaux brésiliens quarante-cinq centavos
 money	fr	brl	-1	moins un réal brésilien zéro centavo
-money	fr	brl	-2	moins deux réals brésiliens zéro centavo
-money	fr	brl	-41.5	moins quarante et un réals brésiliens cinquante centavos
-money	fr	brl	-1000	moins mille réals brésiliens zéro centavo
-money	fr	brl	1.999	deux réals brésiliens zéro centavo
-money	fr	brl	123.456	cent vingt-trois réals brésiliens quarante-six centavos
+money	fr	brl	-2	moins deux réaux brésiliens zéro centavo
+money	fr	brl	-41.5	moins quarante et un réaux brésiliens cinquante centavos
+money	fr	brl	-1000	moins mille réaux brésiliens zéro centavo
+money	fr	brl	1.999	deux réaux brésiliens zéro centavo
+money	fr	brl	123.456	cent vingt-trois réaux brésiliens quarante-six centavos
 money	fr	brl	1.005	un réal brésilien un centavo
 money	fr	uzs	0	zéro sum ouzbek zéro tiyin
 money	fr	uzs	0.01	zéro sum ouzbek un tiyin
@@ -2610,45 +2610,45 @@ money	pt	brl	-1000	menos um mil reais e zero centavo
 money	pt	brl	1.999	dois reais e zero centavo
 money	pt	brl	123.456	cento e vinte e três reais e quarenta e seis centavos
 money	pt	brl	1.005	um real e um centavo
-money	pt	uzs	0	zero som uzbeque e zero tiyin
-money	pt	uzs	0.01	zero som uzbeque e um tiyin
-money	pt	uzs	0.02	zero som uzbeque e dois tiyin
-money	pt	uzs	1	um som uzbeque e zero tiyin
-money	pt	uzs	1.01	um som uzbeque e um tiyin
-money	pt	uzs	1.02	um som uzbeque e dois tiyin
-money	pt	uzs	2	dois soms uzbeques e zero tiyin
-money	pt	uzs	2.02	dois soms uzbeques e dois tiyin
-money	pt	uzs	3	três soms uzbeques e zero tiyin
-money	pt	uzs	5	cinco soms uzbeques e zero tiyin
-money	pt	uzs	11	onze soms uzbeques e zero tiyin
-money	pt	uzs	21	vinte e um soms uzbeques e zero tiyin
-money	pt	uzs	22	vinte e dois soms uzbeques e zero tiyin
-money	pt	uzs	42	quarenta e dois soms uzbeques e zero tiyin
-money	pt	uzs	100	cem soms uzbeques e zero tiyin
-money	pt	uzs	101	cento e um soms uzbeques e zero tiyin
-money	pt	uzs	121	cento e vinte e um soms uzbeques e zero tiyin
-money	pt	uzs	999	novecentos e noventa e nove soms uzbeques e zero tiyin
-money	pt	uzs	1000	um mil soms uzbeques e zero tiyin
-money	pt	uzs	1001	um mil e um soms uzbeques e zero tiyin
-money	pt	uzs	2000	dois mil soms uzbeques e zero tiyin
-money	pt	uzs	2001	dois mil e um soms uzbeques e zero tiyin
-money	pt	uzs	5000	cinco mil soms uzbeques e zero tiyin
-money	pt	uzs	21000	vinte e um mil soms uzbeques e zero tiyin
-money	pt	uzs	22000	vinte e dois mil soms uzbeques e zero tiyin
-money	pt	uzs	41000	quarenta e um mil soms uzbeques e zero tiyin
-money	pt	uzs	42000	quarenta e dois mil soms uzbeques e zero tiyin
-money	pt	uzs	100000	cem mil soms uzbeques e zero tiyin
-money	pt	uzs	1000000	um milhão soms uzbeques e zero tiyin
-money	pt	uzs	2000000	dois milhões soms uzbeques e zero tiyin
-money	pt	uzs	1000000000	um bilhão soms uzbeques e zero tiyin
-money	pt	uzs	123.45	cento e vinte e três soms uzbeques e quarenta e cinco tiyin
-money	pt	uzs	-1	menos um som uzbeque e zero tiyin
-money	pt	uzs	-2	menos dois soms uzbeques e zero tiyin
-money	pt	uzs	-41.5	menos quarenta e um soms uzbeques e cinquenta tiyin
-money	pt	uzs	-1000	menos um mil soms uzbeques e zero tiyin
-money	pt	uzs	1.999	dois soms uzbeques e zero tiyin
-money	pt	uzs	123.456	cento e vinte e três soms uzbeques e quarenta e seis tiyin
-money	pt	uzs	1.005	um som uzbeque e um tiyin
+money	pt	uzs	0	zero sum usbeque e zero tiyin
+money	pt	uzs	0.01	zero sum usbeque e um tiyin
+money	pt	uzs	0.02	zero sum usbeque e dois tiyin
+money	pt	uzs	1	um sum usbeque e zero tiyin
+money	pt	uzs	1.01	um sum usbeque e um tiyin
+money	pt	uzs	1.02	um sum usbeque e dois tiyin
+money	pt	uzs	2	dois sumes usbeques e zero tiyin
+money	pt	uzs	2.02	dois sumes usbeques e dois tiyin
+money	pt	uzs	3	três sumes usbeques e zero tiyin
+money	pt	uzs	5	cinco sumes usbeques e zero tiyin
+money	pt	uzs	11	onze sumes usbeques e zero tiyin
+money	pt	uzs	21	vinte e um sumes usbeques e zero tiyin
+money	pt	uzs	22	vinte e dois sumes usbeques e zero tiyin
+money	pt	uzs	42	quarenta e dois sumes usbeques e zero tiyin
+money	pt	uzs	100	cem sumes usbeques e zero tiyin
+money	pt	uzs	101	cento e um sumes usbeques e zero tiyin
+money	pt	uzs	121	cento e vinte e um sumes usbeques e zero tiyin
+money	pt	uzs	999	novecentos e noventa e nove sumes usbeques e zero tiyin
+money	pt	uzs	1000	um mil sumes usbeques e zero tiyin
+money	pt	uzs	1001	um mil e um sumes usbeques e zero tiyin
+money	pt	uzs	2000	dois mil sumes usbeques e zero tiyin
+money	pt	uzs	2001	dois mil e um sumes usbeques e zero tiyin
+money	pt	uzs	5000	cinco mil sumes usbeques e zero tiyin
+money	pt	uzs	21000	vinte e um mil sumes usbeques e zero tiyin
+money	pt	uzs	22000	vinte e dois mil sumes usbeques e zero tiyin
+money	pt	uzs	41000	quarenta e um mil sumes usbeques e zero tiyin
+money	pt	uzs	42000	quarenta e dois mil sumes usbeques e zero tiyin
+money	pt	uzs	100000	cem mil sumes usbeques e zero tiyin
+money	pt	uzs	1000000	um milhão sumes usbeques e zero tiyin
+money	pt	uzs	2000000	dois milhões sumes usbeques e zero tiyin
+money	pt	uzs	1000000000	um bilhão sumes usbeques e zero tiyin
+money	pt	uzs	123.45	cento e vinte e três sumes usbeques e quarenta e cinco tiyin
+money	pt	uzs	-1	menos um sum usbeque e zero tiyin
+money	pt	uzs	-2	menos dois sumes usbeques e zero tiyin
+money	pt	uzs	-41.5	menos quarenta e um sumes usbeques e cinquenta tiyin
+money	pt	uzs	-1000	menos um mil sumes usbeques e zero tiyin
+money	pt	uzs	1.999	dois sumes usbeques e zero tiyin
+money	pt	uzs	123.456	cento e vinte e três sumes usbeques e quarenta e seis tiyin
+money	pt	uzs	1.005	um sum usbeque e um tiyin
 money	pt	gbp	0	zero libra esterlina e zero pêni
 money	pt	gbp	0.01	zero libra esterlina e um pêni
 money	pt	gbp	0.02	zero libra esterlina e dois pence
@@ -7076,28 +7076,28 @@ money	lv	usd	11	vienpadsmit ASV dolāri un nulle centu
 money	lv	usd	21	divdesmit viens ASV dolārs un nulle centu
 money	lv	usd	22	divdesmit divi ASV dolāri un nulle centu
 money	lv	usd	42	četrdesmit divi ASV dolāri un nulle centu
-money	lv	usd	100	simts ASV dolāri un nulle centu
+money	lv	usd	100	simts ASV dolāru un nulle centu
 money	lv	usd	101	simts viens ASV dolārs un nulle centu
 money	lv	usd	121	simts divdesmit viens ASV dolārs un nulle centu
 money	lv	usd	999	deviņi simti deviņdesmit deviņi ASV dolāri un nulle centu
-money	lv	usd	1000	viens tūkstotis ASV dolāri un nulle centu
+money	lv	usd	1000	viens tūkstotis ASV dolāru un nulle centu
 money	lv	usd	1001	viens tūkstotis viens ASV dolārs un nulle centu
-money	lv	usd	2000	divi tūkstoši ASV dolāri un nulle centu
+money	lv	usd	2000	divi tūkstoši ASV dolāru un nulle centu
 money	lv	usd	2001	divi tūkstoši viens ASV dolārs un nulle centu
-money	lv	usd	5000	pieci tūkstoši ASV dolāri un nulle centu
-money	lv	usd	21000	divdesmit viens tūkstotis ASV dolāri un nulle centu
-money	lv	usd	22000	divdesmit divi tūkstoši ASV dolāri un nulle centu
-money	lv	usd	41000	četrdesmit viens tūkstotis ASV dolāri un nulle centu
-money	lv	usd	42000	četrdesmit divi tūkstoši ASV dolāri un nulle centu
-money	lv	usd	100000	simts tūkstoši ASV dolāri un nulle centu
-money	lv	usd	1000000	viens miljons ASV dolāri un nulle centu
-money	lv	usd	2000000	divi miljoni ASV dolāri un nulle centu
-money	lv	usd	1000000000	viens miljards ASV dolāri un nulle centu
+money	lv	usd	5000	pieci tūkstoši ASV dolāru un nulle centu
+money	lv	usd	21000	divdesmit viens tūkstotis ASV dolāru un nulle centu
+money	lv	usd	22000	divdesmit divi tūkstoši ASV dolāru un nulle centu
+money	lv	usd	41000	četrdesmit viens tūkstotis ASV dolāru un nulle centu
+money	lv	usd	42000	četrdesmit divi tūkstoši ASV dolāru un nulle centu
+money	lv	usd	100000	simts tūkstoši ASV dolāru un nulle centu
+money	lv	usd	1000000	viens miljons ASV dolāru un nulle centu
+money	lv	usd	2000000	divi miljoni ASV dolāru un nulle centu
+money	lv	usd	1000000000	viens miljards ASV dolāru un nulle centu
 money	lv	usd	123.45	simts divdesmit trīs ASV dolāri un četrdesmit pieci centi
 money	lv	usd	-1	mīnus viens ASV dolārs un nulle centu
 money	lv	usd	-2	mīnus divi ASV dolāri un nulle centu
 money	lv	usd	-41.5	mīnus četrdesmit viens ASV dolārs un piecdesmit centi
-money	lv	usd	-1000	mīnus viens tūkstotis ASV dolāri un nulle centu
+money	lv	usd	-1000	mīnus viens tūkstotis ASV dolāru un nulle centu
 money	lv	usd	1.999	divi ASV dolāri un nulle centu
 money	lv	usd	123.456	simts divdesmit trīs ASV dolāri un četrdesmit seši centi
 money	lv	usd	1.005	viens ASV dolārs un viens cents
@@ -7115,28 +7115,28 @@ money	lv	rub	11	vienpadsmit Krievijas rubļi un nulle kapeiku
 money	lv	rub	21	divdesmit viens Krievijas rublis un nulle kapeiku
 money	lv	rub	22	divdesmit divi Krievijas rubļi un nulle kapeiku
 money	lv	rub	42	četrdesmit divi Krievijas rubļi un nulle kapeiku
-money	lv	rub	100	simts Krievijas rubļi un nulle kapeiku
+money	lv	rub	100	simts Krievijas rubļu un nulle kapeiku
 money	lv	rub	101	simts viens Krievijas rublis un nulle kapeiku
 money	lv	rub	121	simts divdesmit viens Krievijas rublis un nulle kapeiku
 money	lv	rub	999	deviņi simti deviņdesmit deviņi Krievijas rubļi un nulle kapeiku
-money	lv	rub	1000	viens tūkstotis Krievijas rubļi un nulle kapeiku
+money	lv	rub	1000	viens tūkstotis Krievijas rubļu un nulle kapeiku
 money	lv	rub	1001	viens tūkstotis viens Krievijas rublis un nulle kapeiku
-money	lv	rub	2000	divi tūkstoši Krievijas rubļi un nulle kapeiku
+money	lv	rub	2000	divi tūkstoši Krievijas rubļu un nulle kapeiku
 money	lv	rub	2001	divi tūkstoši viens Krievijas rublis un nulle kapeiku
-money	lv	rub	5000	pieci tūkstoši Krievijas rubļi un nulle kapeiku
-money	lv	rub	21000	divdesmit viens tūkstotis Krievijas rubļi un nulle kapeiku
-money	lv	rub	22000	divdesmit divi tūkstoši Krievijas rubļi un nulle kapeiku
-money	lv	rub	41000	četrdesmit viens tūkstotis Krievijas rubļi un nulle kapeiku
-money	lv	rub	42000	četrdesmit divi tūkstoši Krievijas rubļi un nulle kapeiku
-money	lv	rub	100000	simts tūkstoši Krievijas rubļi un nulle kapeiku
-money	lv	rub	1000000	viens miljons Krievijas rubļi un nulle kapeiku
-money	lv	rub	2000000	divi miljoni Krievijas rubļi un nulle kapeiku
-money	lv	rub	1000000000	viens miljards Krievijas rubļi un nulle kapeiku
+money	lv	rub	5000	pieci tūkstoši Krievijas rubļu un nulle kapeiku
+money	lv	rub	21000	divdesmit viens tūkstotis Krievijas rubļu un nulle kapeiku
+money	lv	rub	22000	divdesmit divi tūkstoši Krievijas rubļu un nulle kapeiku
+money	lv	rub	41000	četrdesmit viens tūkstotis Krievijas rubļu un nulle kapeiku
+money	lv	rub	42000	četrdesmit divi tūkstoši Krievijas rubļu un nulle kapeiku
+money	lv	rub	100000	simts tūkstoši Krievijas rubļu un nulle kapeiku
+money	lv	rub	1000000	viens miljons Krievijas rubļu un nulle kapeiku
+money	lv	rub	2000000	divi miljoni Krievijas rubļu un nulle kapeiku
+money	lv	rub	1000000000	viens miljards Krievijas rubļu un nulle kapeiku
 money	lv	rub	123.45	simts divdesmit trīs Krievijas rubļi un četrdesmit pieci kapeikas
 money	lv	rub	-1	mīnus viens Krievijas rublis un nulle kapeiku
 money	lv	rub	-2	mīnus divi Krievijas rubļi un nulle kapeiku
 money	lv	rub	-41.5	mīnus četrdesmit viens Krievijas rublis un piecdesmit kapeikas
-money	lv	rub	-1000	mīnus viens tūkstotis Krievijas rubļi un nulle kapeiku
+money	lv	rub	-1000	mīnus viens tūkstotis Krievijas rubļu un nulle kapeiku
 money	lv	rub	1.999	divi Krievijas rubļi un nulle kapeiku
 money	lv	rub	123.456	simts divdesmit trīs Krievijas rubļi un četrdesmit seši kapeikas
 money	lv	rub	1.005	viens Krievijas rublis un viena kapeika
@@ -7154,28 +7154,28 @@ money	lv	try	11	vienpadsmit Turcijas liras un nulle kurusu
 money	lv	try	21	divdesmit viena Turcijas lira un nulle kurusu
 money	lv	try	22	divdesmit divas Turcijas liras un nulle kurusu
 money	lv	try	42	četrdesmit divas Turcijas liras un nulle kurusu
-money	lv	try	100	simts Turcijas liras un nulle kurusu
+money	lv	try	100	simts Turcijas liru un nulle kurusu
 money	lv	try	101	simts viena Turcijas lira un nulle kurusu
 money	lv	try	121	simts divdesmit viena Turcijas lira un nulle kurusu
 money	lv	try	999	deviņi simti deviņdesmit deviņi Turcijas liras un nulle kurusu
-money	lv	try	1000	viens tūkstotis Turcijas liras un nulle kurusu
+money	lv	try	1000	viens tūkstotis Turcijas liru un nulle kurusu
 money	lv	try	1001	viens tūkstotis viena Turcijas lira un nulle kurusu
-money	lv	try	2000	divi tūkstoši Turcijas liras un nulle kurusu
+money	lv	try	2000	divi tūkstoši Turcijas liru un nulle kurusu
 money	lv	try	2001	divi tūkstoši viena Turcijas lira un nulle kurusu
-money	lv	try	5000	pieci tūkstoši Turcijas liras un nulle kurusu
-money	lv	try	21000	divdesmit viens tūkstotis Turcijas liras un nulle kurusu
-money	lv	try	22000	divdesmit divi tūkstoši Turcijas liras un nulle kurusu
-money	lv	try	41000	četrdesmit viens tūkstotis Turcijas liras un nulle kurusu
-money	lv	try	42000	četrdesmit divi tūkstoši Turcijas liras un nulle kurusu
-money	lv	try	100000	simts tūkstoši Turcijas liras un nulle kurusu
-money	lv	try	1000000	viens miljons Turcijas liras un nulle kurusu
-money	lv	try	2000000	divi miljoni Turcijas liras un nulle kurusu
-money	lv	try	1000000000	viens miljards Turcijas liras un nulle kurusu
+money	lv	try	5000	pieci tūkstoši Turcijas liru un nulle kurusu
+money	lv	try	21000	divdesmit viens tūkstotis Turcijas liru un nulle kurusu
+money	lv	try	22000	divdesmit divi tūkstoši Turcijas liru un nulle kurusu
+money	lv	try	41000	četrdesmit viens tūkstotis Turcijas liru un nulle kurusu
+money	lv	try	42000	četrdesmit divi tūkstoši Turcijas liru un nulle kurusu
+money	lv	try	100000	simts tūkstoši Turcijas liru un nulle kurusu
+money	lv	try	1000000	viens miljons Turcijas liru un nulle kurusu
+money	lv	try	2000000	divi miljoni Turcijas liru un nulle kurusu
+money	lv	try	1000000000	viens miljards Turcijas liru un nulle kurusu
 money	lv	try	123.45	simts divdesmit trīs Turcijas liras un četrdesmit pieci kurusi
 money	lv	try	-1	mīnus viena Turcijas lira un nulle kurusu
 money	lv	try	-2	mīnus divas Turcijas liras un nulle kurusu
 money	lv	try	-41.5	mīnus četrdesmit viena Turcijas lira un piecdesmit kurusi
-money	lv	try	-1000	mīnus viens tūkstotis Turcijas liras un nulle kurusu
+money	lv	try	-1000	mīnus viens tūkstotis Turcijas liru un nulle kurusu
 money	lv	try	1.999	divas Turcijas liras un nulle kurusu
 money	lv	try	123.456	simts divdesmit trīs Turcijas liras un četrdesmit seši kurusi
 money	lv	try	1.005	viena Turcijas lira un viens kuruss
@@ -7193,28 +7193,28 @@ money	lv	uah	11	vienpadsmit Ukrainas grivnas un nulle kapeiku
 money	lv	uah	21	divdesmit viena Ukrainas grivna un nulle kapeiku
 money	lv	uah	22	divdesmit divas Ukrainas grivnas un nulle kapeiku
 money	lv	uah	42	četrdesmit divas Ukrainas grivnas un nulle kapeiku
-money	lv	uah	100	simts Ukrainas grivnas un nulle kapeiku
+money	lv	uah	100	simts Ukrainas grivnu un nulle kapeiku
 money	lv	uah	101	simts viena Ukrainas grivna un nulle kapeiku
 money	lv	uah	121	simts divdesmit viena Ukrainas grivna un nulle kapeiku
 money	lv	uah	999	deviņi simti deviņdesmit deviņi Ukrainas grivnas un nulle kapeiku
-money	lv	uah	1000	viens tūkstotis Ukrainas grivnas un nulle kapeiku
+money	lv	uah	1000	viens tūkstotis Ukrainas grivnu un nulle kapeiku
 money	lv	uah	1001	viens tūkstotis viena Ukrainas grivna un nulle kapeiku
-money	lv	uah	2000	divi tūkstoši Ukrainas grivnas un nulle kapeiku
+money	lv	uah	2000	divi tūkstoši Ukrainas grivnu un nulle kapeiku
 money	lv	uah	2001	divi tūkstoši viena Ukrainas grivna un nulle kapeiku
-money	lv	uah	5000	pieci tūkstoši Ukrainas grivnas un nulle kapeiku
-money	lv	uah	21000	divdesmit viens tūkstotis Ukrainas grivnas un nulle kapeiku
-money	lv	uah	22000	divdesmit divi tūkstoši Ukrainas grivnas un nulle kapeiku
-money	lv	uah	41000	četrdesmit viens tūkstotis Ukrainas grivnas un nulle kapeiku
-money	lv	uah	42000	četrdesmit divi tūkstoši Ukrainas grivnas un nulle kapeiku
-money	lv	uah	100000	simts tūkstoši Ukrainas grivnas un nulle kapeiku
-money	lv	uah	1000000	viens miljons Ukrainas grivnas un nulle kapeiku
-money	lv	uah	2000000	divi miljoni Ukrainas grivnas un nulle kapeiku
-money	lv	uah	1000000000	viens miljards Ukrainas grivnas un nulle kapeiku
+money	lv	uah	5000	pieci tūkstoši Ukrainas grivnu un nulle kapeiku
+money	lv	uah	21000	divdesmit viens tūkstotis Ukrainas grivnu un nulle kapeiku
+money	lv	uah	22000	divdesmit divi tūkstoši Ukrainas grivnu un nulle kapeiku
+money	lv	uah	41000	četrdesmit viens tūkstotis Ukrainas grivnu un nulle kapeiku
+money	lv	uah	42000	četrdesmit divi tūkstoši Ukrainas grivnu un nulle kapeiku
+money	lv	uah	100000	simts tūkstoši Ukrainas grivnu un nulle kapeiku
+money	lv	uah	1000000	viens miljons Ukrainas grivnu un nulle kapeiku
+money	lv	uah	2000000	divi miljoni Ukrainas grivnu un nulle kapeiku
+money	lv	uah	1000000000	viens miljards Ukrainas grivnu un nulle kapeiku
 money	lv	uah	123.45	simts divdesmit trīs Ukrainas grivnas un četrdesmit pieci kapeikas
 money	lv	uah	-1	mīnus viena Ukrainas grivna un nulle kapeiku
 money	lv	uah	-2	mīnus divas Ukrainas grivnas un nulle kapeiku
 money	lv	uah	-41.5	mīnus četrdesmit viena Ukrainas grivna un piecdesmit kapeikas
-money	lv	uah	-1000	mīnus viens tūkstotis Ukrainas grivnas un nulle kapeiku
+money	lv	uah	-1000	mīnus viens tūkstotis Ukrainas grivnu un nulle kapeiku
 money	lv	uah	1.999	divas Ukrainas grivnas un nulle kapeiku
 money	lv	uah	123.456	simts divdesmit trīs Ukrainas grivnas un četrdesmit seši kapeikas
 money	lv	uah	1.005	viena Ukrainas grivna un viena kapeika
@@ -7232,28 +7232,28 @@ money	lv	bgn	11	vienpadsmit Bulgārijas levas un nulle stotinku
 money	lv	bgn	21	divdesmit viena Bulgārijas leva un nulle stotinku
 money	lv	bgn	22	divdesmit divas Bulgārijas levas un nulle stotinku
 money	lv	bgn	42	četrdesmit divas Bulgārijas levas un nulle stotinku
-money	lv	bgn	100	simts Bulgārijas levas un nulle stotinku
+money	lv	bgn	100	simts Bulgārijas levu un nulle stotinku
 money	lv	bgn	101	simts viena Bulgārijas leva un nulle stotinku
 money	lv	bgn	121	simts divdesmit viena Bulgārijas leva un nulle stotinku
 money	lv	bgn	999	deviņi simti deviņdesmit deviņi Bulgārijas levas un nulle stotinku
-money	lv	bgn	1000	viens tūkstotis Bulgārijas levas un nulle stotinku
+money	lv	bgn	1000	viens tūkstotis Bulgārijas levu un nulle stotinku
 money	lv	bgn	1001	viens tūkstotis viena Bulgārijas leva un nulle stotinku
-money	lv	bgn	2000	divi tūkstoši Bulgārijas levas un nulle stotinku
+money	lv	bgn	2000	divi tūkstoši Bulgārijas levu un nulle stotinku
 money	lv	bgn	2001	divi tūkstoši viena Bulgārijas leva un nulle stotinku
-money	lv	bgn	5000	pieci tūkstoši Bulgārijas levas un nulle stotinku
-money	lv	bgn	21000	divdesmit viens tūkstotis Bulgārijas levas un nulle stotinku
-money	lv	bgn	22000	divdesmit divi tūkstoši Bulgārijas levas un nulle stotinku
-money	lv	bgn	41000	četrdesmit viens tūkstotis Bulgārijas levas un nulle stotinku
-money	lv	bgn	42000	četrdesmit divi tūkstoši Bulgārijas levas un nulle stotinku
-money	lv	bgn	100000	simts tūkstoši Bulgārijas levas un nulle stotinku
-money	lv	bgn	1000000	viens miljons Bulgārijas levas un nulle stotinku
-money	lv	bgn	2000000	divi miljoni Bulgārijas levas un nulle stotinku
-money	lv	bgn	1000000000	viens miljards Bulgārijas levas un nulle stotinku
+money	lv	bgn	5000	pieci tūkstoši Bulgārijas levu un nulle stotinku
+money	lv	bgn	21000	divdesmit viens tūkstotis Bulgārijas levu un nulle stotinku
+money	lv	bgn	22000	divdesmit divi tūkstoši Bulgārijas levu un nulle stotinku
+money	lv	bgn	41000	četrdesmit viens tūkstotis Bulgārijas levu un nulle stotinku
+money	lv	bgn	42000	četrdesmit divi tūkstoši Bulgārijas levu un nulle stotinku
+money	lv	bgn	100000	simts tūkstoši Bulgārijas levu un nulle stotinku
+money	lv	bgn	1000000	viens miljons Bulgārijas levu un nulle stotinku
+money	lv	bgn	2000000	divi miljoni Bulgārijas levu un nulle stotinku
+money	lv	bgn	1000000000	viens miljards Bulgārijas levu un nulle stotinku
 money	lv	bgn	123.45	simts divdesmit trīs Bulgārijas levas un četrdesmit pieci stotinkas
 money	lv	bgn	-1	mīnus viena Bulgārijas leva un nulle stotinku
 money	lv	bgn	-2	mīnus divas Bulgārijas levas un nulle stotinku
 money	lv	bgn	-41.5	mīnus četrdesmit viena Bulgārijas leva un piecdesmit stotinkas
-money	lv	bgn	-1000	mīnus viens tūkstotis Bulgārijas levas un nulle stotinku
+money	lv	bgn	-1000	mīnus viens tūkstotis Bulgārijas levu un nulle stotinku
 money	lv	bgn	1.999	divas Bulgārijas levas un nulle stotinku
 money	lv	bgn	123.456	simts divdesmit trīs Bulgārijas levas un četrdesmit seši stotinkas
 money	lv	bgn	1.005	viena Bulgārijas leva un viena stotinka
@@ -7271,28 +7271,28 @@ money	lv	etb	11	vienpadsmit Etiopijas biri un nulle santīmu
 money	lv	etb	21	divdesmit viens Etiopijas birs un nulle santīmu
 money	lv	etb	22	divdesmit divi Etiopijas biri un nulle santīmu
 money	lv	etb	42	četrdesmit divi Etiopijas biri un nulle santīmu
-money	lv	etb	100	simts Etiopijas biri un nulle santīmu
+money	lv	etb	100	simts Etiopijas biru un nulle santīmu
 money	lv	etb	101	simts viens Etiopijas birs un nulle santīmu
 money	lv	etb	121	simts divdesmit viens Etiopijas birs un nulle santīmu
 money	lv	etb	999	deviņi simti deviņdesmit deviņi Etiopijas biri un nulle santīmu
-money	lv	etb	1000	viens tūkstotis Etiopijas biri un nulle santīmu
+money	lv	etb	1000	viens tūkstotis Etiopijas biru un nulle santīmu
 money	lv	etb	1001	viens tūkstotis viens Etiopijas birs un nulle santīmu
-money	lv	etb	2000	divi tūkstoši Etiopijas biri un nulle santīmu
+money	lv	etb	2000	divi tūkstoši Etiopijas biru un nulle santīmu
 money	lv	etb	2001	divi tūkstoši viens Etiopijas birs un nulle santīmu
-money	lv	etb	5000	pieci tūkstoši Etiopijas biri un nulle santīmu
-money	lv	etb	21000	divdesmit viens tūkstotis Etiopijas biri un nulle santīmu
-money	lv	etb	22000	divdesmit divi tūkstoši Etiopijas biri un nulle santīmu
-money	lv	etb	41000	četrdesmit viens tūkstotis Etiopijas biri un nulle santīmu
-money	lv	etb	42000	četrdesmit divi tūkstoši Etiopijas biri un nulle santīmu
-money	lv	etb	100000	simts tūkstoši Etiopijas biri un nulle santīmu
-money	lv	etb	1000000	viens miljons Etiopijas biri un nulle santīmu
-money	lv	etb	2000000	divi miljoni Etiopijas biri un nulle santīmu
-money	lv	etb	1000000000	viens miljards Etiopijas biri un nulle santīmu
+money	lv	etb	5000	pieci tūkstoši Etiopijas biru un nulle santīmu
+money	lv	etb	21000	divdesmit viens tūkstotis Etiopijas biru un nulle santīmu
+money	lv	etb	22000	divdesmit divi tūkstoši Etiopijas biru un nulle santīmu
+money	lv	etb	41000	četrdesmit viens tūkstotis Etiopijas biru un nulle santīmu
+money	lv	etb	42000	četrdesmit divi tūkstoši Etiopijas biru un nulle santīmu
+money	lv	etb	100000	simts tūkstoši Etiopijas biru un nulle santīmu
+money	lv	etb	1000000	viens miljons Etiopijas biru un nulle santīmu
+money	lv	etb	2000000	divi miljoni Etiopijas biru un nulle santīmu
+money	lv	etb	1000000000	viens miljards Etiopijas biru un nulle santīmu
 money	lv	etb	123.45	simts divdesmit trīs Etiopijas biri un četrdesmit pieci santīmi
 money	lv	etb	-1	mīnus viens Etiopijas birs un nulle santīmu
 money	lv	etb	-2	mīnus divi Etiopijas biri un nulle santīmu
 money	lv	etb	-41.5	mīnus četrdesmit viens Etiopijas birs un piecdesmit santīmi
-money	lv	etb	-1000	mīnus viens tūkstotis Etiopijas biri un nulle santīmu
+money	lv	etb	-1000	mīnus viens tūkstotis Etiopijas biru un nulle santīmu
 money	lv	etb	1.999	divi Etiopijas biri un nulle santīmu
 money	lv	etb	123.456	simts divdesmit trīs Etiopijas biri un četrdesmit seši santīmi
 money	lv	etb	1.005	viens Etiopijas birs un viens santīms
@@ -7310,28 +7310,28 @@ money	lv	pln	11	vienpadsmit Polijas zloti un nulle grašu
 money	lv	pln	21	divdesmit viens Polijas zlots un nulle grašu
 money	lv	pln	22	divdesmit divi Polijas zloti un nulle grašu
 money	lv	pln	42	četrdesmit divi Polijas zloti un nulle grašu
-money	lv	pln	100	simts Polijas zloti un nulle grašu
+money	lv	pln	100	simts Polijas zlotu un nulle grašu
 money	lv	pln	101	simts viens Polijas zlots un nulle grašu
 money	lv	pln	121	simts divdesmit viens Polijas zlots un nulle grašu
 money	lv	pln	999	deviņi simti deviņdesmit deviņi Polijas zloti un nulle grašu
-money	lv	pln	1000	viens tūkstotis Polijas zloti un nulle grašu
+money	lv	pln	1000	viens tūkstotis Polijas zlotu un nulle grašu
 money	lv	pln	1001	viens tūkstotis viens Polijas zlots un nulle grašu
-money	lv	pln	2000	divi tūkstoši Polijas zloti un nulle grašu
+money	lv	pln	2000	divi tūkstoši Polijas zlotu un nulle grašu
 money	lv	pln	2001	divi tūkstoši viens Polijas zlots un nulle grašu
-money	lv	pln	5000	pieci tūkstoši Polijas zloti un nulle grašu
-money	lv	pln	21000	divdesmit viens tūkstotis Polijas zloti un nulle grašu
-money	lv	pln	22000	divdesmit divi tūkstoši Polijas zloti un nulle grašu
-money	lv	pln	41000	četrdesmit viens tūkstotis Polijas zloti un nulle grašu
-money	lv	pln	42000	četrdesmit divi tūkstoši Polijas zloti un nulle grašu
-money	lv	pln	100000	simts tūkstoši Polijas zloti un nulle grašu
-money	lv	pln	1000000	viens miljons Polijas zloti un nulle grašu
-money	lv	pln	2000000	divi miljoni Polijas zloti un nulle grašu
-money	lv	pln	1000000000	viens miljards Polijas zloti un nulle grašu
+money	lv	pln	5000	pieci tūkstoši Polijas zlotu un nulle grašu
+money	lv	pln	21000	divdesmit viens tūkstotis Polijas zlotu un nulle grašu
+money	lv	pln	22000	divdesmit divi tūkstoši Polijas zlotu un nulle grašu
+money	lv	pln	41000	četrdesmit viens tūkstotis Polijas zlotu un nulle grašu
+money	lv	pln	42000	četrdesmit divi tūkstoši Polijas zlotu un nulle grašu
+money	lv	pln	100000	simts tūkstoši Polijas zlotu un nulle grašu
+money	lv	pln	1000000	viens miljons Polijas zlotu un nulle grašu
+money	lv	pln	2000000	divi miljoni Polijas zlotu un nulle grašu
+money	lv	pln	1000000000	viens miljards Polijas zlotu un nulle grašu
 money	lv	pln	123.45	simts divdesmit trīs Polijas zloti un četrdesmit pieci graši
 money	lv	pln	-1	mīnus viens Polijas zlots un nulle grašu
 money	lv	pln	-2	mīnus divi Polijas zloti un nulle grašu
 money	lv	pln	-41.5	mīnus četrdesmit viens Polijas zlots un piecdesmit graši
-money	lv	pln	-1000	mīnus viens tūkstotis Polijas zloti un nulle grašu
+money	lv	pln	-1000	mīnus viens tūkstotis Polijas zlotu un nulle grašu
 money	lv	pln	1.999	divi Polijas zloti un nulle grašu
 money	lv	pln	123.456	simts divdesmit trīs Polijas zloti un četrdesmit seši graši
 money	lv	pln	1.005	viens Polijas zlots un viens grasis
@@ -7349,28 +7349,28 @@ money	lv	byn	11	vienpadsmit Baltkrievijas rubļi un nulle kapeiku
 money	lv	byn	21	divdesmit viens Baltkrievijas rublis un nulle kapeiku
 money	lv	byn	22	divdesmit divi Baltkrievijas rubļi un nulle kapeiku
 money	lv	byn	42	četrdesmit divi Baltkrievijas rubļi un nulle kapeiku
-money	lv	byn	100	simts Baltkrievijas rubļi un nulle kapeiku
+money	lv	byn	100	simts Baltkrievijas rubļu un nulle kapeiku
 money	lv	byn	101	simts viens Baltkrievijas rublis un nulle kapeiku
 money	lv	byn	121	simts divdesmit viens Baltkrievijas rublis un nulle kapeiku
 money	lv	byn	999	deviņi simti deviņdesmit deviņi Baltkrievijas rubļi un nulle kapeiku
-money	lv	byn	1000	viens tūkstotis Baltkrievijas rubļi un nulle kapeiku
+money	lv	byn	1000	viens tūkstotis Baltkrievijas rubļu un nulle kapeiku
 money	lv	byn	1001	viens tūkstotis viens Baltkrievijas rublis un nulle kapeiku
-money	lv	byn	2000	divi tūkstoši Baltkrievijas rubļi un nulle kapeiku
+money	lv	byn	2000	divi tūkstoši Baltkrievijas rubļu un nulle kapeiku
 money	lv	byn	2001	divi tūkstoši viens Baltkrievijas rublis un nulle kapeiku
-money	lv	byn	5000	pieci tūkstoši Baltkrievijas rubļi un nulle kapeiku
-money	lv	byn	21000	divdesmit viens tūkstotis Baltkrievijas rubļi un nulle kapeiku
-money	lv	byn	22000	divdesmit divi tūkstoši Baltkrievijas rubļi un nulle kapeiku
-money	lv	byn	41000	četrdesmit viens tūkstotis Baltkrievijas rubļi un nulle kapeiku
-money	lv	byn	42000	četrdesmit divi tūkstoši Baltkrievijas rubļi un nulle kapeiku
-money	lv	byn	100000	simts tūkstoši Baltkrievijas rubļi un nulle kapeiku
-money	lv	byn	1000000	viens miljons Baltkrievijas rubļi un nulle kapeiku
-money	lv	byn	2000000	divi miljoni Baltkrievijas rubļi un nulle kapeiku
-money	lv	byn	1000000000	viens miljards Baltkrievijas rubļi un nulle kapeiku
+money	lv	byn	5000	pieci tūkstoši Baltkrievijas rubļu un nulle kapeiku
+money	lv	byn	21000	divdesmit viens tūkstotis Baltkrievijas rubļu un nulle kapeiku
+money	lv	byn	22000	divdesmit divi tūkstoši Baltkrievijas rubļu un nulle kapeiku
+money	lv	byn	41000	četrdesmit viens tūkstotis Baltkrievijas rubļu un nulle kapeiku
+money	lv	byn	42000	četrdesmit divi tūkstoši Baltkrievijas rubļu un nulle kapeiku
+money	lv	byn	100000	simts tūkstoši Baltkrievijas rubļu un nulle kapeiku
+money	lv	byn	1000000	viens miljons Baltkrievijas rubļu un nulle kapeiku
+money	lv	byn	2000000	divi miljoni Baltkrievijas rubļu un nulle kapeiku
+money	lv	byn	1000000000	viens miljards Baltkrievijas rubļu un nulle kapeiku
 money	lv	byn	123.45	simts divdesmit trīs Baltkrievijas rubļi un četrdesmit pieci kapeikas
 money	lv	byn	-1	mīnus viens Baltkrievijas rublis un nulle kapeiku
 money	lv	byn	-2	mīnus divi Baltkrievijas rubļi un nulle kapeiku
 money	lv	byn	-41.5	mīnus četrdesmit viens Baltkrievijas rublis un piecdesmit kapeikas
-money	lv	byn	-1000	mīnus viens tūkstotis Baltkrievijas rubļi un nulle kapeiku
+money	lv	byn	-1000	mīnus viens tūkstotis Baltkrievijas rubļu un nulle kapeiku
 money	lv	byn	1.999	divi Baltkrievijas rubļi un nulle kapeiku
 money	lv	byn	123.456	simts divdesmit trīs Baltkrievijas rubļi un četrdesmit seši kapeikas
 money	lv	byn	1.005	viens Baltkrievijas rublis un viena kapeika
@@ -7427,28 +7427,28 @@ money	lv	brl	11	vienpadsmit Brazīlijas reāli un nulle centavo
 money	lv	brl	21	divdesmit viens Brazīlijas reāls un nulle centavo
 money	lv	brl	22	divdesmit divi Brazīlijas reāli un nulle centavo
 money	lv	brl	42	četrdesmit divi Brazīlijas reāli un nulle centavo
-money	lv	brl	100	simts Brazīlijas reāli un nulle centavo
+money	lv	brl	100	simts Brazīlijas reālu un nulle centavo
 money	lv	brl	101	simts viens Brazīlijas reāls un nulle centavo
 money	lv	brl	121	simts divdesmit viens Brazīlijas reāls un nulle centavo
 money	lv	brl	999	deviņi simti deviņdesmit deviņi Brazīlijas reāli un nulle centavo
-money	lv	brl	1000	viens tūkstotis Brazīlijas reāli un nulle centavo
+money	lv	brl	1000	viens tūkstotis Brazīlijas reālu un nulle centavo
 money	lv	brl	1001	viens tūkstotis viens Brazīlijas reāls un nulle centavo
-money	lv	brl	2000	divi tūkstoši Brazīlijas reāli un nulle centavo
+money	lv	brl	2000	divi tūkstoši Brazīlijas reālu un nulle centavo
 money	lv	brl	2001	divi tūkstoši viens Brazīlijas reāls un nulle centavo
-money	lv	brl	5000	pieci tūkstoši Brazīlijas reāli un nulle centavo
-money	lv	brl	21000	divdesmit viens tūkstotis Brazīlijas reāli un nulle centavo
-money	lv	brl	22000	divdesmit divi tūkstoši Brazīlijas reāli un nulle centavo
-money	lv	brl	41000	četrdesmit viens tūkstotis Brazīlijas reāli un nulle centavo
-money	lv	brl	42000	četrdesmit divi tūkstoši Brazīlijas reāli un nulle centavo
-money	lv	brl	100000	simts tūkstoši Brazīlijas reāli un nulle centavo
-money	lv	brl	1000000	viens miljons Brazīlijas reāli un nulle centavo
-money	lv	brl	2000000	divi miljoni Brazīlijas reāli un nulle centavo
-money	lv	brl	1000000000	viens miljards Brazīlijas reāli un nulle centavo
+money	lv	brl	5000	pieci tūkstoši Brazīlijas reālu un nulle centavo
+money	lv	brl	21000	divdesmit viens tūkstotis Brazīlijas reālu un nulle centavo
+money	lv	brl	22000	divdesmit divi tūkstoši Brazīlijas reālu un nulle centavo
+money	lv	brl	41000	četrdesmit viens tūkstotis Brazīlijas reālu un nulle centavo
+money	lv	brl	42000	četrdesmit divi tūkstoši Brazīlijas reālu un nulle centavo
+money	lv	brl	100000	simts tūkstoši Brazīlijas reālu un nulle centavo
+money	lv	brl	1000000	viens miljons Brazīlijas reālu un nulle centavo
+money	lv	brl	2000000	divi miljoni Brazīlijas reālu un nulle centavo
+money	lv	brl	1000000000	viens miljards Brazīlijas reālu un nulle centavo
 money	lv	brl	123.45	simts divdesmit trīs Brazīlijas reāli un četrdesmit pieci centavo
 money	lv	brl	-1	mīnus viens Brazīlijas reāls un nulle centavo
 money	lv	brl	-2	mīnus divi Brazīlijas reāli un nulle centavo
 money	lv	brl	-41.5	mīnus četrdesmit viens Brazīlijas reāls un piecdesmit centavo
-money	lv	brl	-1000	mīnus viens tūkstotis Brazīlijas reāli un nulle centavo
+money	lv	brl	-1000	mīnus viens tūkstotis Brazīlijas reālu un nulle centavo
 money	lv	brl	1.999	divi Brazīlijas reāli un nulle centavo
 money	lv	brl	123.456	simts divdesmit trīs Brazīlijas reāli un četrdesmit seši centavo
 money	lv	brl	1.005	viens Brazīlijas reāls un viens centavo
@@ -7466,28 +7466,28 @@ money	lv	uzs	11	vienpadsmit Uzbekistānas sumi un nulle tijinu
 money	lv	uzs	21	divdesmit viens Uzbekistānas sums un nulle tijinu
 money	lv	uzs	22	divdesmit divi Uzbekistānas sumi un nulle tijinu
 money	lv	uzs	42	četrdesmit divi Uzbekistānas sumi un nulle tijinu
-money	lv	uzs	100	simts Uzbekistānas sumi un nulle tijinu
+money	lv	uzs	100	simts Uzbekistānas sumu un nulle tijinu
 money	lv	uzs	101	simts viens Uzbekistānas sums un nulle tijinu
 money	lv	uzs	121	simts divdesmit viens Uzbekistānas sums un nulle tijinu
 money	lv	uzs	999	deviņi simti deviņdesmit deviņi Uzbekistānas sumi un nulle tijinu
-money	lv	uzs	1000	viens tūkstotis Uzbekistānas sumi un nulle tijinu
+money	lv	uzs	1000	viens tūkstotis Uzbekistānas sumu un nulle tijinu
 money	lv	uzs	1001	viens tūkstotis viens Uzbekistānas sums un nulle tijinu
-money	lv	uzs	2000	divi tūkstoši Uzbekistānas sumi un nulle tijinu
+money	lv	uzs	2000	divi tūkstoši Uzbekistānas sumu un nulle tijinu
 money	lv	uzs	2001	divi tūkstoši viens Uzbekistānas sums un nulle tijinu
-money	lv	uzs	5000	pieci tūkstoši Uzbekistānas sumi un nulle tijinu
-money	lv	uzs	21000	divdesmit viens tūkstotis Uzbekistānas sumi un nulle tijinu
-money	lv	uzs	22000	divdesmit divi tūkstoši Uzbekistānas sumi un nulle tijinu
-money	lv	uzs	41000	četrdesmit viens tūkstotis Uzbekistānas sumi un nulle tijinu
-money	lv	uzs	42000	četrdesmit divi tūkstoši Uzbekistānas sumi un nulle tijinu
-money	lv	uzs	100000	simts tūkstoši Uzbekistānas sumi un nulle tijinu
-money	lv	uzs	1000000	viens miljons Uzbekistānas sumi un nulle tijinu
-money	lv	uzs	2000000	divi miljoni Uzbekistānas sumi un nulle tijinu
-money	lv	uzs	1000000000	viens miljards Uzbekistānas sumi un nulle tijinu
+money	lv	uzs	5000	pieci tūkstoši Uzbekistānas sumu un nulle tijinu
+money	lv	uzs	21000	divdesmit viens tūkstotis Uzbekistānas sumu un nulle tijinu
+money	lv	uzs	22000	divdesmit divi tūkstoši Uzbekistānas sumu un nulle tijinu
+money	lv	uzs	41000	četrdesmit viens tūkstotis Uzbekistānas sumu un nulle tijinu
+money	lv	uzs	42000	četrdesmit divi tūkstoši Uzbekistānas sumu un nulle tijinu
+money	lv	uzs	100000	simts tūkstoši Uzbekistānas sumu un nulle tijinu
+money	lv	uzs	1000000	viens miljons Uzbekistānas sumu un nulle tijinu
+money	lv	uzs	2000000	divi miljoni Uzbekistānas sumu un nulle tijinu
+money	lv	uzs	1000000000	viens miljards Uzbekistānas sumu un nulle tijinu
 money	lv	uzs	123.45	simts divdesmit trīs Uzbekistānas sumi un četrdesmit pieci tijini
 money	lv	uzs	-1	mīnus viens Uzbekistānas sums un nulle tijinu
 money	lv	uzs	-2	mīnus divi Uzbekistānas sumi un nulle tijinu
 money	lv	uzs	-41.5	mīnus četrdesmit viens Uzbekistānas sums un piecdesmit tijini
-money	lv	uzs	-1000	mīnus viens tūkstotis Uzbekistānas sumi un nulle tijinu
+money	lv	uzs	-1000	mīnus viens tūkstotis Uzbekistānas sumu un nulle tijinu
 money	lv	uzs	1.999	divi Uzbekistānas sumi un nulle tijinu
 money	lv	uzs	123.456	simts divdesmit trīs Uzbekistānas sumi un četrdesmit seši tijini
 money	lv	uzs	1.005	viens Uzbekistānas sums un viens tijins
@@ -7505,28 +7505,28 @@ money	lv	gbp	11	vienpadsmit sterliņu mārciņas un nulle pensu
 money	lv	gbp	21	divdesmit viena sterliņu mārciņa un nulle pensu
 money	lv	gbp	22	divdesmit divas sterliņu mārciņas un nulle pensu
 money	lv	gbp	42	četrdesmit divas sterliņu mārciņas un nulle pensu
-money	lv	gbp	100	simts sterliņu mārciņas un nulle pensu
+money	lv	gbp	100	simts sterliņu mārciņu un nulle pensu
 money	lv	gbp	101	simts viena sterliņu mārciņa un nulle pensu
 money	lv	gbp	121	simts divdesmit viena sterliņu mārciņa un nulle pensu
 money	lv	gbp	999	deviņi simti deviņdesmit deviņi sterliņu mārciņas un nulle pensu
-money	lv	gbp	1000	viens tūkstotis sterliņu mārciņas un nulle pensu
+money	lv	gbp	1000	viens tūkstotis sterliņu mārciņu un nulle pensu
 money	lv	gbp	1001	viens tūkstotis viena sterliņu mārciņa un nulle pensu
-money	lv	gbp	2000	divi tūkstoši sterliņu mārciņas un nulle pensu
+money	lv	gbp	2000	divi tūkstoši sterliņu mārciņu un nulle pensu
 money	lv	gbp	2001	divi tūkstoši viena sterliņu mārciņa un nulle pensu
-money	lv	gbp	5000	pieci tūkstoši sterliņu mārciņas un nulle pensu
-money	lv	gbp	21000	divdesmit viens tūkstotis sterliņu mārciņas un nulle pensu
-money	lv	gbp	22000	divdesmit divi tūkstoši sterliņu mārciņas un nulle pensu
-money	lv	gbp	41000	četrdesmit viens tūkstotis sterliņu mārciņas un nulle pensu
-money	lv	gbp	42000	četrdesmit divi tūkstoši sterliņu mārciņas un nulle pensu
-money	lv	gbp	100000	simts tūkstoši sterliņu mārciņas un nulle pensu
-money	lv	gbp	1000000	viens miljons sterliņu mārciņas un nulle pensu
-money	lv	gbp	2000000	divi miljoni sterliņu mārciņas un nulle pensu
-money	lv	gbp	1000000000	viens miljards sterliņu mārciņas un nulle pensu
+money	lv	gbp	5000	pieci tūkstoši sterliņu mārciņu un nulle pensu
+money	lv	gbp	21000	divdesmit viens tūkstotis sterliņu mārciņu un nulle pensu
+money	lv	gbp	22000	divdesmit divi tūkstoši sterliņu mārciņu un nulle pensu
+money	lv	gbp	41000	četrdesmit viens tūkstotis sterliņu mārciņu un nulle pensu
+money	lv	gbp	42000	četrdesmit divi tūkstoši sterliņu mārciņu un nulle pensu
+money	lv	gbp	100000	simts tūkstoši sterliņu mārciņu un nulle pensu
+money	lv	gbp	1000000	viens miljons sterliņu mārciņu un nulle pensu
+money	lv	gbp	2000000	divi miljoni sterliņu mārciņu un nulle pensu
+money	lv	gbp	1000000000	viens miljards sterliņu mārciņu un nulle pensu
 money	lv	gbp	123.45	simts divdesmit trīs sterliņu mārciņas un četrdesmit pieci pensi
 money	lv	gbp	-1	mīnus viena sterliņu mārciņa un nulle pensu
 money	lv	gbp	-2	mīnus divas sterliņu mārciņas un nulle pensu
 money	lv	gbp	-41.5	mīnus četrdesmit viena sterliņu mārciņa un piecdesmit pensi
-money	lv	gbp	-1000	mīnus viens tūkstotis sterliņu mārciņas un nulle pensu
+money	lv	gbp	-1000	mīnus viens tūkstotis sterliņu mārciņu un nulle pensu
 money	lv	gbp	1.999	divas sterliņu mārciņas un nulle pensu
 money	lv	gbp	123.456	simts divdesmit trīs sterliņu mārciņas un četrdesmit seši pensi
 money	lv	gbp	1.005	viena sterliņu mārciņa un viens penss

--- a/src/Nut.Tests/behaviour-snapshot.tsv
+++ b/src/Nut.Tests/behaviour-snapshot.tsv
@@ -6485,45 +6485,45 @@ plain	uz	-2	minus ikki
 plain	uz	-41	minus qirq bir
 plain	uz	-1000	minus ming
 plain	uz	-1000000	minus bir million
-money	uz	eur	0	nol yevro nol sent
-money	uz	eur	0.01	nol yevro bir sent
-money	uz	eur	0.02	nol yevro ikki sent
-money	uz	eur	1	bir yevro nol sent
-money	uz	eur	1.01	bir yevro bir sent
-money	uz	eur	1.02	bir yevro ikki sent
-money	uz	eur	2	ikki yevro nol sent
-money	uz	eur	2.02	ikki yevro ikki sent
-money	uz	eur	3	uch yevro nol sent
-money	uz	eur	5	besh yevro nol sent
-money	uz	eur	11	o'n bir yevro nol sent
-money	uz	eur	21	yigirma bir yevro nol sent
-money	uz	eur	22	yigirma ikki yevro nol sent
-money	uz	eur	42	qirq ikki yevro nol sent
-money	uz	eur	100	yuz yevro nol sent
-money	uz	eur	101	yuz bir yevro nol sent
-money	uz	eur	121	yuz yigirma bir yevro nol sent
-money	uz	eur	999	to'qqiz yuz to'qson to'qqiz yevro nol sent
-money	uz	eur	1000	ming yevro nol sent
-money	uz	eur	1001	ming bir yevro nol sent
-money	uz	eur	2000	ikki ming yevro nol sent
-money	uz	eur	2001	ikki ming bir yevro nol sent
-money	uz	eur	5000	besh ming yevro nol sent
-money	uz	eur	21000	yigirma bir ming yevro nol sent
-money	uz	eur	22000	yigirma ikki ming yevro nol sent
-money	uz	eur	41000	qirq bir ming yevro nol sent
-money	uz	eur	42000	qirq ikki ming yevro nol sent
-money	uz	eur	100000	yuz ming yevro nol sent
-money	uz	eur	1000000	bir million yevro nol sent
-money	uz	eur	2000000	ikki million yevro nol sent
-money	uz	eur	1000000000	bir milliard yevro nol sent
-money	uz	eur	123.45	yuz yigirma uch yevro qirq besh sent
-money	uz	eur	-1	minus bir yevro nol sent
-money	uz	eur	-2	minus ikki yevro nol sent
-money	uz	eur	-41.5	minus qirq bir yevro ellik sent
-money	uz	eur	-1000	minus ming yevro nol sent
-money	uz	eur	1.999	ikki yevro nol sent
-money	uz	eur	123.456	yuz yigirma uch yevro qirq olti sent
-money	uz	eur	1.005	bir yevro bir sent
+money	uz	eur	0	EX:NotSupportedException
+money	uz	eur	0.01	EX:NotSupportedException
+money	uz	eur	0.02	EX:NotSupportedException
+money	uz	eur	1	EX:NotSupportedException
+money	uz	eur	1.01	EX:NotSupportedException
+money	uz	eur	1.02	EX:NotSupportedException
+money	uz	eur	2	EX:NotSupportedException
+money	uz	eur	2.02	EX:NotSupportedException
+money	uz	eur	3	EX:NotSupportedException
+money	uz	eur	5	EX:NotSupportedException
+money	uz	eur	11	EX:NotSupportedException
+money	uz	eur	21	EX:NotSupportedException
+money	uz	eur	22	EX:NotSupportedException
+money	uz	eur	42	EX:NotSupportedException
+money	uz	eur	100	EX:NotSupportedException
+money	uz	eur	101	EX:NotSupportedException
+money	uz	eur	121	EX:NotSupportedException
+money	uz	eur	999	EX:NotSupportedException
+money	uz	eur	1000	EX:NotSupportedException
+money	uz	eur	1001	EX:NotSupportedException
+money	uz	eur	2000	EX:NotSupportedException
+money	uz	eur	2001	EX:NotSupportedException
+money	uz	eur	5000	EX:NotSupportedException
+money	uz	eur	21000	EX:NotSupportedException
+money	uz	eur	22000	EX:NotSupportedException
+money	uz	eur	41000	EX:NotSupportedException
+money	uz	eur	42000	EX:NotSupportedException
+money	uz	eur	100000	EX:NotSupportedException
+money	uz	eur	1000000	EX:NotSupportedException
+money	uz	eur	2000000	EX:NotSupportedException
+money	uz	eur	1000000000	EX:NotSupportedException
+money	uz	eur	123.45	EX:NotSupportedException
+money	uz	eur	-1	EX:NotSupportedException
+money	uz	eur	-2	EX:NotSupportedException
+money	uz	eur	-41.5	EX:NotSupportedException
+money	uz	eur	-1000	EX:NotSupportedException
+money	uz	eur	1.999	EX:NotSupportedException
+money	uz	eur	123.456	EX:NotSupportedException
+money	uz	eur	1.005	EX:NotSupportedException
 money	uz	usd	0	nol dollar nol sent
 money	uz	usd	0.01	nol dollar bir sent
 money	uz	usd	0.02	nol dollar ikki sent
@@ -6563,357 +6563,357 @@ money	uz	usd	-1000	minus ming dollar nol sent
 money	uz	usd	1.999	ikki dollar nol sent
 money	uz	usd	123.456	yuz yigirma uch dollar qirq olti sent
 money	uz	usd	1.005	bir dollar bir sent
-money	uz	rub	0	nol rubl nol tiyin
-money	uz	rub	0.01	nol rubl bir tiyin
-money	uz	rub	0.02	nol rubl ikki tiyin
-money	uz	rub	1	bir rubl nol tiyin
-money	uz	rub	1.01	bir rubl bir tiyin
-money	uz	rub	1.02	bir rubl ikki tiyin
-money	uz	rub	2	ikki rubl nol tiyin
-money	uz	rub	2.02	ikki rubl ikki tiyin
-money	uz	rub	3	uch rubl nol tiyin
-money	uz	rub	5	besh rubl nol tiyin
-money	uz	rub	11	o'n bir rubl nol tiyin
-money	uz	rub	21	yigirma bir rubl nol tiyin
-money	uz	rub	22	yigirma ikki rubl nol tiyin
-money	uz	rub	42	qirq ikki rubl nol tiyin
-money	uz	rub	100	yuz rubl nol tiyin
-money	uz	rub	101	yuz bir rubl nol tiyin
-money	uz	rub	121	yuz yigirma bir rubl nol tiyin
-money	uz	rub	999	to'qqiz yuz to'qson to'qqiz rubl nol tiyin
-money	uz	rub	1000	ming rubl nol tiyin
-money	uz	rub	1001	ming bir rubl nol tiyin
-money	uz	rub	2000	ikki ming rubl nol tiyin
-money	uz	rub	2001	ikki ming bir rubl nol tiyin
-money	uz	rub	5000	besh ming rubl nol tiyin
-money	uz	rub	21000	yigirma bir ming rubl nol tiyin
-money	uz	rub	22000	yigirma ikki ming rubl nol tiyin
-money	uz	rub	41000	qirq bir ming rubl nol tiyin
-money	uz	rub	42000	qirq ikki ming rubl nol tiyin
-money	uz	rub	100000	yuz ming rubl nol tiyin
-money	uz	rub	1000000	bir million rubl nol tiyin
-money	uz	rub	2000000	ikki million rubl nol tiyin
-money	uz	rub	1000000000	bir milliard rubl nol tiyin
-money	uz	rub	123.45	yuz yigirma uch rubl qirq besh tiyin
-money	uz	rub	-1	minus bir rubl nol tiyin
-money	uz	rub	-2	minus ikki rubl nol tiyin
-money	uz	rub	-41.5	minus qirq bir rubl ellik tiyin
-money	uz	rub	-1000	minus ming rubl nol tiyin
-money	uz	rub	1.999	ikki rubl nol tiyin
-money	uz	rub	123.456	yuz yigirma uch rubl qirq olti tiyin
-money	uz	rub	1.005	bir rubl bir tiyin
-money	uz	try	0	nol turk lirasi nol tiyin
-money	uz	try	0.01	nol turk lirasi bir tiyin
-money	uz	try	0.02	nol turk lirasi ikki tiyin
-money	uz	try	1	bir turk lirasi nol tiyin
-money	uz	try	1.01	bir turk lirasi bir tiyin
-money	uz	try	1.02	bir turk lirasi ikki tiyin
-money	uz	try	2	ikki turk lirasi nol tiyin
-money	uz	try	2.02	ikki turk lirasi ikki tiyin
-money	uz	try	3	uch turk lirasi nol tiyin
-money	uz	try	5	besh turk lirasi nol tiyin
-money	uz	try	11	o'n bir turk lirasi nol tiyin
-money	uz	try	21	yigirma bir turk lirasi nol tiyin
-money	uz	try	22	yigirma ikki turk lirasi nol tiyin
-money	uz	try	42	qirq ikki turk lirasi nol tiyin
-money	uz	try	100	yuz turk lirasi nol tiyin
-money	uz	try	101	yuz bir turk lirasi nol tiyin
-money	uz	try	121	yuz yigirma bir turk lirasi nol tiyin
-money	uz	try	999	to'qqiz yuz to'qson to'qqiz turk lirasi nol tiyin
-money	uz	try	1000	ming turk lirasi nol tiyin
-money	uz	try	1001	ming bir turk lirasi nol tiyin
-money	uz	try	2000	ikki ming turk lirasi nol tiyin
-money	uz	try	2001	ikki ming bir turk lirasi nol tiyin
-money	uz	try	5000	besh ming turk lirasi nol tiyin
-money	uz	try	21000	yigirma bir ming turk lirasi nol tiyin
-money	uz	try	22000	yigirma ikki ming turk lirasi nol tiyin
-money	uz	try	41000	qirq bir ming turk lirasi nol tiyin
-money	uz	try	42000	qirq ikki ming turk lirasi nol tiyin
-money	uz	try	100000	yuz ming turk lirasi nol tiyin
-money	uz	try	1000000	bir million turk lirasi nol tiyin
-money	uz	try	2000000	ikki million turk lirasi nol tiyin
-money	uz	try	1000000000	bir milliard turk lirasi nol tiyin
-money	uz	try	123.45	yuz yigirma uch turk lirasi qirq besh tiyin
-money	uz	try	-1	minus bir turk lirasi nol tiyin
-money	uz	try	-2	minus ikki turk lirasi nol tiyin
-money	uz	try	-41.5	minus qirq bir turk lirasi ellik tiyin
-money	uz	try	-1000	minus ming turk lirasi nol tiyin
-money	uz	try	1.999	ikki turk lirasi nol tiyin
-money	uz	try	123.456	yuz yigirma uch turk lirasi qirq olti tiyin
-money	uz	try	1.005	bir turk lirasi bir tiyin
-money	uz	uah	0	nol Ukraina grivnasi nol tiyin
-money	uz	uah	0.01	nol Ukraina grivnasi bir tiyin
-money	uz	uah	0.02	nol Ukraina grivnasi ikki tiyin
-money	uz	uah	1	bir Ukraina grivnasi nol tiyin
-money	uz	uah	1.01	bir Ukraina grivnasi bir tiyin
-money	uz	uah	1.02	bir Ukraina grivnasi ikki tiyin
-money	uz	uah	2	ikki Ukraina grivnasi nol tiyin
-money	uz	uah	2.02	ikki Ukraina grivnasi ikki tiyin
-money	uz	uah	3	uch Ukraina grivnasi nol tiyin
-money	uz	uah	5	besh Ukraina grivnasi nol tiyin
-money	uz	uah	11	o'n bir Ukraina grivnasi nol tiyin
-money	uz	uah	21	yigirma bir Ukraina grivnasi nol tiyin
-money	uz	uah	22	yigirma ikki Ukraina grivnasi nol tiyin
-money	uz	uah	42	qirq ikki Ukraina grivnasi nol tiyin
-money	uz	uah	100	yuz Ukraina grivnasi nol tiyin
-money	uz	uah	101	yuz bir Ukraina grivnasi nol tiyin
-money	uz	uah	121	yuz yigirma bir Ukraina grivnasi nol tiyin
-money	uz	uah	999	to'qqiz yuz to'qson to'qqiz Ukraina grivnasi nol tiyin
-money	uz	uah	1000	ming Ukraina grivnasi nol tiyin
-money	uz	uah	1001	ming bir Ukraina grivnasi nol tiyin
-money	uz	uah	2000	ikki ming Ukraina grivnasi nol tiyin
-money	uz	uah	2001	ikki ming bir Ukraina grivnasi nol tiyin
-money	uz	uah	5000	besh ming Ukraina grivnasi nol tiyin
-money	uz	uah	21000	yigirma bir ming Ukraina grivnasi nol tiyin
-money	uz	uah	22000	yigirma ikki ming Ukraina grivnasi nol tiyin
-money	uz	uah	41000	qirq bir ming Ukraina grivnasi nol tiyin
-money	uz	uah	42000	qirq ikki ming Ukraina grivnasi nol tiyin
-money	uz	uah	100000	yuz ming Ukraina grivnasi nol tiyin
-money	uz	uah	1000000	bir million Ukraina grivnasi nol tiyin
-money	uz	uah	2000000	ikki million Ukraina grivnasi nol tiyin
-money	uz	uah	1000000000	bir milliard Ukraina grivnasi nol tiyin
-money	uz	uah	123.45	yuz yigirma uch Ukraina grivnasi qirq besh tiyin
-money	uz	uah	-1	minus bir Ukraina grivnasi nol tiyin
-money	uz	uah	-2	minus ikki Ukraina grivnasi nol tiyin
-money	uz	uah	-41.5	minus qirq bir Ukraina grivnasi ellik tiyin
-money	uz	uah	-1000	minus ming Ukraina grivnasi nol tiyin
-money	uz	uah	1.999	ikki Ukraina grivnasi nol tiyin
-money	uz	uah	123.456	yuz yigirma uch Ukraina grivnasi qirq olti tiyin
-money	uz	uah	1.005	bir Ukraina grivnasi bir tiyin
-money	uz	bgn	0	nol Bolgariya levi nol stotinka
-money	uz	bgn	0.01	nol Bolgariya levi bir stotinka
-money	uz	bgn	0.02	nol Bolgariya levi ikki stotinka
-money	uz	bgn	1	bir Bolgariya levi nol stotinka
-money	uz	bgn	1.01	bir Bolgariya levi bir stotinka
-money	uz	bgn	1.02	bir Bolgariya levi ikki stotinka
-money	uz	bgn	2	ikki Bolgariya levi nol stotinka
-money	uz	bgn	2.02	ikki Bolgariya levi ikki stotinka
-money	uz	bgn	3	uch Bolgariya levi nol stotinka
-money	uz	bgn	5	besh Bolgariya levi nol stotinka
-money	uz	bgn	11	o'n bir Bolgariya levi nol stotinka
-money	uz	bgn	21	yigirma bir Bolgariya levi nol stotinka
-money	uz	bgn	22	yigirma ikki Bolgariya levi nol stotinka
-money	uz	bgn	42	qirq ikki Bolgariya levi nol stotinka
-money	uz	bgn	100	yuz Bolgariya levi nol stotinka
-money	uz	bgn	101	yuz bir Bolgariya levi nol stotinka
-money	uz	bgn	121	yuz yigirma bir Bolgariya levi nol stotinka
-money	uz	bgn	999	to'qqiz yuz to'qson to'qqiz Bolgariya levi nol stotinka
-money	uz	bgn	1000	ming Bolgariya levi nol stotinka
-money	uz	bgn	1001	ming bir Bolgariya levi nol stotinka
-money	uz	bgn	2000	ikki ming Bolgariya levi nol stotinka
-money	uz	bgn	2001	ikki ming bir Bolgariya levi nol stotinka
-money	uz	bgn	5000	besh ming Bolgariya levi nol stotinka
-money	uz	bgn	21000	yigirma bir ming Bolgariya levi nol stotinka
-money	uz	bgn	22000	yigirma ikki ming Bolgariya levi nol stotinka
-money	uz	bgn	41000	qirq bir ming Bolgariya levi nol stotinka
-money	uz	bgn	42000	qirq ikki ming Bolgariya levi nol stotinka
-money	uz	bgn	100000	yuz ming Bolgariya levi nol stotinka
-money	uz	bgn	1000000	bir million Bolgariya levi nol stotinka
-money	uz	bgn	2000000	ikki million Bolgariya levi nol stotinka
-money	uz	bgn	1000000000	bir milliard Bolgariya levi nol stotinka
-money	uz	bgn	123.45	yuz yigirma uch Bolgariya levi qirq besh stotinka
-money	uz	bgn	-1	minus bir Bolgariya levi nol stotinka
-money	uz	bgn	-2	minus ikki Bolgariya levi nol stotinka
-money	uz	bgn	-41.5	minus qirq bir Bolgariya levi ellik stotinka
-money	uz	bgn	-1000	minus ming Bolgariya levi nol stotinka
-money	uz	bgn	1.999	ikki Bolgariya levi nol stotinka
-money	uz	bgn	123.456	yuz yigirma uch Bolgariya levi qirq olti stotinka
-money	uz	bgn	1.005	bir Bolgariya levi bir stotinka
-money	uz	etb	0	nol Efiopiya biri nol tiyin
-money	uz	etb	0.01	nol Efiopiya biri bir tiyin
-money	uz	etb	0.02	nol Efiopiya biri ikki tiyin
-money	uz	etb	1	bir Efiopiya biri nol tiyin
-money	uz	etb	1.01	bir Efiopiya biri bir tiyin
-money	uz	etb	1.02	bir Efiopiya biri ikki tiyin
-money	uz	etb	2	ikki Efiopiya biri nol tiyin
-money	uz	etb	2.02	ikki Efiopiya biri ikki tiyin
-money	uz	etb	3	uch Efiopiya biri nol tiyin
-money	uz	etb	5	besh Efiopiya biri nol tiyin
-money	uz	etb	11	o'n bir Efiopiya biri nol tiyin
-money	uz	etb	21	yigirma bir Efiopiya biri nol tiyin
-money	uz	etb	22	yigirma ikki Efiopiya biri nol tiyin
-money	uz	etb	42	qirq ikki Efiopiya biri nol tiyin
-money	uz	etb	100	yuz Efiopiya biri nol tiyin
-money	uz	etb	101	yuz bir Efiopiya biri nol tiyin
-money	uz	etb	121	yuz yigirma bir Efiopiya biri nol tiyin
-money	uz	etb	999	to'qqiz yuz to'qson to'qqiz Efiopiya biri nol tiyin
-money	uz	etb	1000	ming Efiopiya biri nol tiyin
-money	uz	etb	1001	ming bir Efiopiya biri nol tiyin
-money	uz	etb	2000	ikki ming Efiopiya biri nol tiyin
-money	uz	etb	2001	ikki ming bir Efiopiya biri nol tiyin
-money	uz	etb	5000	besh ming Efiopiya biri nol tiyin
-money	uz	etb	21000	yigirma bir ming Efiopiya biri nol tiyin
-money	uz	etb	22000	yigirma ikki ming Efiopiya biri nol tiyin
-money	uz	etb	41000	qirq bir ming Efiopiya biri nol tiyin
-money	uz	etb	42000	qirq ikki ming Efiopiya biri nol tiyin
-money	uz	etb	100000	yuz ming Efiopiya biri nol tiyin
-money	uz	etb	1000000	bir million Efiopiya biri nol tiyin
-money	uz	etb	2000000	ikki million Efiopiya biri nol tiyin
-money	uz	etb	1000000000	bir milliard Efiopiya biri nol tiyin
-money	uz	etb	123.45	yuz yigirma uch Efiopiya biri qirq besh tiyin
-money	uz	etb	-1	minus bir Efiopiya biri nol tiyin
-money	uz	etb	-2	minus ikki Efiopiya biri nol tiyin
-money	uz	etb	-41.5	minus qirq bir Efiopiya biri ellik tiyin
-money	uz	etb	-1000	minus ming Efiopiya biri nol tiyin
-money	uz	etb	1.999	ikki Efiopiya biri nol tiyin
-money	uz	etb	123.456	yuz yigirma uch Efiopiya biri qirq olti tiyin
-money	uz	etb	1.005	bir Efiopiya biri bir tiyin
-money	uz	pln	0	nol Polsha zlotiysi nol grosh
-money	uz	pln	0.01	nol Polsha zlotiysi bir grosh
-money	uz	pln	0.02	nol Polsha zlotiysi ikki grosh
-money	uz	pln	1	bir Polsha zlotiysi nol grosh
-money	uz	pln	1.01	bir Polsha zlotiysi bir grosh
-money	uz	pln	1.02	bir Polsha zlotiysi ikki grosh
-money	uz	pln	2	ikki Polsha zlotiysi nol grosh
-money	uz	pln	2.02	ikki Polsha zlotiysi ikki grosh
-money	uz	pln	3	uch Polsha zlotiysi nol grosh
-money	uz	pln	5	besh Polsha zlotiysi nol grosh
-money	uz	pln	11	o'n bir Polsha zlotiysi nol grosh
-money	uz	pln	21	yigirma bir Polsha zlotiysi nol grosh
-money	uz	pln	22	yigirma ikki Polsha zlotiysi nol grosh
-money	uz	pln	42	qirq ikki Polsha zlotiysi nol grosh
-money	uz	pln	100	yuz Polsha zlotiysi nol grosh
-money	uz	pln	101	yuz bir Polsha zlotiysi nol grosh
-money	uz	pln	121	yuz yigirma bir Polsha zlotiysi nol grosh
-money	uz	pln	999	to'qqiz yuz to'qson to'qqiz Polsha zlotiysi nol grosh
-money	uz	pln	1000	ming Polsha zlotiysi nol grosh
-money	uz	pln	1001	ming bir Polsha zlotiysi nol grosh
-money	uz	pln	2000	ikki ming Polsha zlotiysi nol grosh
-money	uz	pln	2001	ikki ming bir Polsha zlotiysi nol grosh
-money	uz	pln	5000	besh ming Polsha zlotiysi nol grosh
-money	uz	pln	21000	yigirma bir ming Polsha zlotiysi nol grosh
-money	uz	pln	22000	yigirma ikki ming Polsha zlotiysi nol grosh
-money	uz	pln	41000	qirq bir ming Polsha zlotiysi nol grosh
-money	uz	pln	42000	qirq ikki ming Polsha zlotiysi nol grosh
-money	uz	pln	100000	yuz ming Polsha zlotiysi nol grosh
-money	uz	pln	1000000	bir million Polsha zlotiysi nol grosh
-money	uz	pln	2000000	ikki million Polsha zlotiysi nol grosh
-money	uz	pln	1000000000	bir milliard Polsha zlotiysi nol grosh
-money	uz	pln	123.45	yuz yigirma uch Polsha zlotiysi qirq besh grosh
-money	uz	pln	-1	minus bir Polsha zlotiysi nol grosh
-money	uz	pln	-2	minus ikki Polsha zlotiysi nol grosh
-money	uz	pln	-41.5	minus qirq bir Polsha zlotiysi ellik grosh
-money	uz	pln	-1000	minus ming Polsha zlotiysi nol grosh
-money	uz	pln	1.999	ikki Polsha zlotiysi nol grosh
-money	uz	pln	123.456	yuz yigirma uch Polsha zlotiysi qirq olti grosh
-money	uz	pln	1.005	bir Polsha zlotiysi bir grosh
-money	uz	byn	0	nol Belarus rubli nol tiyin
-money	uz	byn	0.01	nol Belarus rubli bir tiyin
-money	uz	byn	0.02	nol Belarus rubli ikki tiyin
-money	uz	byn	1	bir Belarus rubli nol tiyin
-money	uz	byn	1.01	bir Belarus rubli bir tiyin
-money	uz	byn	1.02	bir Belarus rubli ikki tiyin
-money	uz	byn	2	ikki Belarus rubli nol tiyin
-money	uz	byn	2.02	ikki Belarus rubli ikki tiyin
-money	uz	byn	3	uch Belarus rubli nol tiyin
-money	uz	byn	5	besh Belarus rubli nol tiyin
-money	uz	byn	11	o'n bir Belarus rubli nol tiyin
-money	uz	byn	21	yigirma bir Belarus rubli nol tiyin
-money	uz	byn	22	yigirma ikki Belarus rubli nol tiyin
-money	uz	byn	42	qirq ikki Belarus rubli nol tiyin
-money	uz	byn	100	yuz Belarus rubli nol tiyin
-money	uz	byn	101	yuz bir Belarus rubli nol tiyin
-money	uz	byn	121	yuz yigirma bir Belarus rubli nol tiyin
-money	uz	byn	999	to'qqiz yuz to'qson to'qqiz Belarus rubli nol tiyin
-money	uz	byn	1000	ming Belarus rubli nol tiyin
-money	uz	byn	1001	ming bir Belarus rubli nol tiyin
-money	uz	byn	2000	ikki ming Belarus rubli nol tiyin
-money	uz	byn	2001	ikki ming bir Belarus rubli nol tiyin
-money	uz	byn	5000	besh ming Belarus rubli nol tiyin
-money	uz	byn	21000	yigirma bir ming Belarus rubli nol tiyin
-money	uz	byn	22000	yigirma ikki ming Belarus rubli nol tiyin
-money	uz	byn	41000	qirq bir ming Belarus rubli nol tiyin
-money	uz	byn	42000	qirq ikki ming Belarus rubli nol tiyin
-money	uz	byn	100000	yuz ming Belarus rubli nol tiyin
-money	uz	byn	1000000	bir million Belarus rubli nol tiyin
-money	uz	byn	2000000	ikki million Belarus rubli nol tiyin
-money	uz	byn	1000000000	bir milliard Belarus rubli nol tiyin
-money	uz	byn	123.45	yuz yigirma uch Belarus rubli qirq besh tiyin
-money	uz	byn	-1	minus bir Belarus rubli nol tiyin
-money	uz	byn	-2	minus ikki Belarus rubli nol tiyin
-money	uz	byn	-41.5	minus qirq bir Belarus rubli ellik tiyin
-money	uz	byn	-1000	minus ming Belarus rubli nol tiyin
-money	uz	byn	1.999	ikki Belarus rubli nol tiyin
-money	uz	byn	123.456	yuz yigirma uch Belarus rubli qirq olti tiyin
-money	uz	byn	1.005	bir Belarus rubli bir tiyin
-money	uz	ars	0	nol Argentina pesosi nol sentavo
-money	uz	ars	0.01	nol Argentina pesosi bir sentavo
-money	uz	ars	0.02	nol Argentina pesosi ikki sentavo
-money	uz	ars	1	bir Argentina pesosi nol sentavo
-money	uz	ars	1.01	bir Argentina pesosi bir sentavo
-money	uz	ars	1.02	bir Argentina pesosi ikki sentavo
-money	uz	ars	2	ikki Argentina pesosi nol sentavo
-money	uz	ars	2.02	ikki Argentina pesosi ikki sentavo
-money	uz	ars	3	uch Argentina pesosi nol sentavo
-money	uz	ars	5	besh Argentina pesosi nol sentavo
-money	uz	ars	11	o'n bir Argentina pesosi nol sentavo
-money	uz	ars	21	yigirma bir Argentina pesosi nol sentavo
-money	uz	ars	22	yigirma ikki Argentina pesosi nol sentavo
-money	uz	ars	42	qirq ikki Argentina pesosi nol sentavo
-money	uz	ars	100	yuz Argentina pesosi nol sentavo
-money	uz	ars	101	yuz bir Argentina pesosi nol sentavo
-money	uz	ars	121	yuz yigirma bir Argentina pesosi nol sentavo
-money	uz	ars	999	to'qqiz yuz to'qson to'qqiz Argentina pesosi nol sentavo
-money	uz	ars	1000	ming Argentina pesosi nol sentavo
-money	uz	ars	1001	ming bir Argentina pesosi nol sentavo
-money	uz	ars	2000	ikki ming Argentina pesosi nol sentavo
-money	uz	ars	2001	ikki ming bir Argentina pesosi nol sentavo
-money	uz	ars	5000	besh ming Argentina pesosi nol sentavo
-money	uz	ars	21000	yigirma bir ming Argentina pesosi nol sentavo
-money	uz	ars	22000	yigirma ikki ming Argentina pesosi nol sentavo
-money	uz	ars	41000	qirq bir ming Argentina pesosi nol sentavo
-money	uz	ars	42000	qirq ikki ming Argentina pesosi nol sentavo
-money	uz	ars	100000	yuz ming Argentina pesosi nol sentavo
-money	uz	ars	1000000	bir million Argentina pesosi nol sentavo
-money	uz	ars	2000000	ikki million Argentina pesosi nol sentavo
-money	uz	ars	1000000000	bir milliard Argentina pesosi nol sentavo
-money	uz	ars	123.45	yuz yigirma uch Argentina pesosi qirq besh sentavo
-money	uz	ars	-1	minus bir Argentina pesosi nol sentavo
-money	uz	ars	-2	minus ikki Argentina pesosi nol sentavo
-money	uz	ars	-41.5	minus qirq bir Argentina pesosi ellik sentavo
-money	uz	ars	-1000	minus ming Argentina pesosi nol sentavo
-money	uz	ars	1.999	ikki Argentina pesosi nol sentavo
-money	uz	ars	123.456	yuz yigirma uch Argentina pesosi qirq olti sentavo
-money	uz	ars	1.005	bir Argentina pesosi bir sentavo
-money	uz	brl	0	nol Braziliya reali nol sentavo
-money	uz	brl	0.01	nol Braziliya reali bir sentavo
-money	uz	brl	0.02	nol Braziliya reali ikki sentavo
-money	uz	brl	1	bir Braziliya reali nol sentavo
-money	uz	brl	1.01	bir Braziliya reali bir sentavo
-money	uz	brl	1.02	bir Braziliya reali ikki sentavo
-money	uz	brl	2	ikki Braziliya reali nol sentavo
-money	uz	brl	2.02	ikki Braziliya reali ikki sentavo
-money	uz	brl	3	uch Braziliya reali nol sentavo
-money	uz	brl	5	besh Braziliya reali nol sentavo
-money	uz	brl	11	o'n bir Braziliya reali nol sentavo
-money	uz	brl	21	yigirma bir Braziliya reali nol sentavo
-money	uz	brl	22	yigirma ikki Braziliya reali nol sentavo
-money	uz	brl	42	qirq ikki Braziliya reali nol sentavo
-money	uz	brl	100	yuz Braziliya reali nol sentavo
-money	uz	brl	101	yuz bir Braziliya reali nol sentavo
-money	uz	brl	121	yuz yigirma bir Braziliya reali nol sentavo
-money	uz	brl	999	to'qqiz yuz to'qson to'qqiz Braziliya reali nol sentavo
-money	uz	brl	1000	ming Braziliya reali nol sentavo
-money	uz	brl	1001	ming bir Braziliya reali nol sentavo
-money	uz	brl	2000	ikki ming Braziliya reali nol sentavo
-money	uz	brl	2001	ikki ming bir Braziliya reali nol sentavo
-money	uz	brl	5000	besh ming Braziliya reali nol sentavo
-money	uz	brl	21000	yigirma bir ming Braziliya reali nol sentavo
-money	uz	brl	22000	yigirma ikki ming Braziliya reali nol sentavo
-money	uz	brl	41000	qirq bir ming Braziliya reali nol sentavo
-money	uz	brl	42000	qirq ikki ming Braziliya reali nol sentavo
-money	uz	brl	100000	yuz ming Braziliya reali nol sentavo
-money	uz	brl	1000000	bir million Braziliya reali nol sentavo
-money	uz	brl	2000000	ikki million Braziliya reali nol sentavo
-money	uz	brl	1000000000	bir milliard Braziliya reali nol sentavo
-money	uz	brl	123.45	yuz yigirma uch Braziliya reali qirq besh sentavo
-money	uz	brl	-1	minus bir Braziliya reali nol sentavo
-money	uz	brl	-2	minus ikki Braziliya reali nol sentavo
-money	uz	brl	-41.5	minus qirq bir Braziliya reali ellik sentavo
-money	uz	brl	-1000	minus ming Braziliya reali nol sentavo
-money	uz	brl	1.999	ikki Braziliya reali nol sentavo
-money	uz	brl	123.456	yuz yigirma uch Braziliya reali qirq olti sentavo
-money	uz	brl	1.005	bir Braziliya reali bir sentavo
+money	uz	rub	0	nol rubl nol kopeyka
+money	uz	rub	0.01	nol rubl bir kopeyka
+money	uz	rub	0.02	nol rubl ikki kopeyka
+money	uz	rub	1	bir rubl nol kopeyka
+money	uz	rub	1.01	bir rubl bir kopeyka
+money	uz	rub	1.02	bir rubl ikki kopeyka
+money	uz	rub	2	ikki rubl nol kopeyka
+money	uz	rub	2.02	ikki rubl ikki kopeyka
+money	uz	rub	3	uch rubl nol kopeyka
+money	uz	rub	5	besh rubl nol kopeyka
+money	uz	rub	11	o'n bir rubl nol kopeyka
+money	uz	rub	21	yigirma bir rubl nol kopeyka
+money	uz	rub	22	yigirma ikki rubl nol kopeyka
+money	uz	rub	42	qirq ikki rubl nol kopeyka
+money	uz	rub	100	yuz rubl nol kopeyka
+money	uz	rub	101	yuz bir rubl nol kopeyka
+money	uz	rub	121	yuz yigirma bir rubl nol kopeyka
+money	uz	rub	999	to'qqiz yuz to'qson to'qqiz rubl nol kopeyka
+money	uz	rub	1000	ming rubl nol kopeyka
+money	uz	rub	1001	ming bir rubl nol kopeyka
+money	uz	rub	2000	ikki ming rubl nol kopeyka
+money	uz	rub	2001	ikki ming bir rubl nol kopeyka
+money	uz	rub	5000	besh ming rubl nol kopeyka
+money	uz	rub	21000	yigirma bir ming rubl nol kopeyka
+money	uz	rub	22000	yigirma ikki ming rubl nol kopeyka
+money	uz	rub	41000	qirq bir ming rubl nol kopeyka
+money	uz	rub	42000	qirq ikki ming rubl nol kopeyka
+money	uz	rub	100000	yuz ming rubl nol kopeyka
+money	uz	rub	1000000	bir million rubl nol kopeyka
+money	uz	rub	2000000	ikki million rubl nol kopeyka
+money	uz	rub	1000000000	bir milliard rubl nol kopeyka
+money	uz	rub	123.45	yuz yigirma uch rubl qirq besh kopeyka
+money	uz	rub	-1	minus bir rubl nol kopeyka
+money	uz	rub	-2	minus ikki rubl nol kopeyka
+money	uz	rub	-41.5	minus qirq bir rubl ellik kopeyka
+money	uz	rub	-1000	minus ming rubl nol kopeyka
+money	uz	rub	1.999	ikki rubl nol kopeyka
+money	uz	rub	123.456	yuz yigirma uch rubl qirq olti kopeyka
+money	uz	rub	1.005	bir rubl bir kopeyka
+money	uz	try	0	EX:NotSupportedException
+money	uz	try	0.01	EX:NotSupportedException
+money	uz	try	0.02	EX:NotSupportedException
+money	uz	try	1	EX:NotSupportedException
+money	uz	try	1.01	EX:NotSupportedException
+money	uz	try	1.02	EX:NotSupportedException
+money	uz	try	2	EX:NotSupportedException
+money	uz	try	2.02	EX:NotSupportedException
+money	uz	try	3	EX:NotSupportedException
+money	uz	try	5	EX:NotSupportedException
+money	uz	try	11	EX:NotSupportedException
+money	uz	try	21	EX:NotSupportedException
+money	uz	try	22	EX:NotSupportedException
+money	uz	try	42	EX:NotSupportedException
+money	uz	try	100	EX:NotSupportedException
+money	uz	try	101	EX:NotSupportedException
+money	uz	try	121	EX:NotSupportedException
+money	uz	try	999	EX:NotSupportedException
+money	uz	try	1000	EX:NotSupportedException
+money	uz	try	1001	EX:NotSupportedException
+money	uz	try	2000	EX:NotSupportedException
+money	uz	try	2001	EX:NotSupportedException
+money	uz	try	5000	EX:NotSupportedException
+money	uz	try	21000	EX:NotSupportedException
+money	uz	try	22000	EX:NotSupportedException
+money	uz	try	41000	EX:NotSupportedException
+money	uz	try	42000	EX:NotSupportedException
+money	uz	try	100000	EX:NotSupportedException
+money	uz	try	1000000	EX:NotSupportedException
+money	uz	try	2000000	EX:NotSupportedException
+money	uz	try	1000000000	EX:NotSupportedException
+money	uz	try	123.45	EX:NotSupportedException
+money	uz	try	-1	EX:NotSupportedException
+money	uz	try	-2	EX:NotSupportedException
+money	uz	try	-41.5	EX:NotSupportedException
+money	uz	try	-1000	EX:NotSupportedException
+money	uz	try	1.999	EX:NotSupportedException
+money	uz	try	123.456	EX:NotSupportedException
+money	uz	try	1.005	EX:NotSupportedException
+money	uz	uah	0	EX:NotSupportedException
+money	uz	uah	0.01	EX:NotSupportedException
+money	uz	uah	0.02	EX:NotSupportedException
+money	uz	uah	1	EX:NotSupportedException
+money	uz	uah	1.01	EX:NotSupportedException
+money	uz	uah	1.02	EX:NotSupportedException
+money	uz	uah	2	EX:NotSupportedException
+money	uz	uah	2.02	EX:NotSupportedException
+money	uz	uah	3	EX:NotSupportedException
+money	uz	uah	5	EX:NotSupportedException
+money	uz	uah	11	EX:NotSupportedException
+money	uz	uah	21	EX:NotSupportedException
+money	uz	uah	22	EX:NotSupportedException
+money	uz	uah	42	EX:NotSupportedException
+money	uz	uah	100	EX:NotSupportedException
+money	uz	uah	101	EX:NotSupportedException
+money	uz	uah	121	EX:NotSupportedException
+money	uz	uah	999	EX:NotSupportedException
+money	uz	uah	1000	EX:NotSupportedException
+money	uz	uah	1001	EX:NotSupportedException
+money	uz	uah	2000	EX:NotSupportedException
+money	uz	uah	2001	EX:NotSupportedException
+money	uz	uah	5000	EX:NotSupportedException
+money	uz	uah	21000	EX:NotSupportedException
+money	uz	uah	22000	EX:NotSupportedException
+money	uz	uah	41000	EX:NotSupportedException
+money	uz	uah	42000	EX:NotSupportedException
+money	uz	uah	100000	EX:NotSupportedException
+money	uz	uah	1000000	EX:NotSupportedException
+money	uz	uah	2000000	EX:NotSupportedException
+money	uz	uah	1000000000	EX:NotSupportedException
+money	uz	uah	123.45	EX:NotSupportedException
+money	uz	uah	-1	EX:NotSupportedException
+money	uz	uah	-2	EX:NotSupportedException
+money	uz	uah	-41.5	EX:NotSupportedException
+money	uz	uah	-1000	EX:NotSupportedException
+money	uz	uah	1.999	EX:NotSupportedException
+money	uz	uah	123.456	EX:NotSupportedException
+money	uz	uah	1.005	EX:NotSupportedException
+money	uz	bgn	0	EX:NotSupportedException
+money	uz	bgn	0.01	EX:NotSupportedException
+money	uz	bgn	0.02	EX:NotSupportedException
+money	uz	bgn	1	EX:NotSupportedException
+money	uz	bgn	1.01	EX:NotSupportedException
+money	uz	bgn	1.02	EX:NotSupportedException
+money	uz	bgn	2	EX:NotSupportedException
+money	uz	bgn	2.02	EX:NotSupportedException
+money	uz	bgn	3	EX:NotSupportedException
+money	uz	bgn	5	EX:NotSupportedException
+money	uz	bgn	11	EX:NotSupportedException
+money	uz	bgn	21	EX:NotSupportedException
+money	uz	bgn	22	EX:NotSupportedException
+money	uz	bgn	42	EX:NotSupportedException
+money	uz	bgn	100	EX:NotSupportedException
+money	uz	bgn	101	EX:NotSupportedException
+money	uz	bgn	121	EX:NotSupportedException
+money	uz	bgn	999	EX:NotSupportedException
+money	uz	bgn	1000	EX:NotSupportedException
+money	uz	bgn	1001	EX:NotSupportedException
+money	uz	bgn	2000	EX:NotSupportedException
+money	uz	bgn	2001	EX:NotSupportedException
+money	uz	bgn	5000	EX:NotSupportedException
+money	uz	bgn	21000	EX:NotSupportedException
+money	uz	bgn	22000	EX:NotSupportedException
+money	uz	bgn	41000	EX:NotSupportedException
+money	uz	bgn	42000	EX:NotSupportedException
+money	uz	bgn	100000	EX:NotSupportedException
+money	uz	bgn	1000000	EX:NotSupportedException
+money	uz	bgn	2000000	EX:NotSupportedException
+money	uz	bgn	1000000000	EX:NotSupportedException
+money	uz	bgn	123.45	EX:NotSupportedException
+money	uz	bgn	-1	EX:NotSupportedException
+money	uz	bgn	-2	EX:NotSupportedException
+money	uz	bgn	-41.5	EX:NotSupportedException
+money	uz	bgn	-1000	EX:NotSupportedException
+money	uz	bgn	1.999	EX:NotSupportedException
+money	uz	bgn	123.456	EX:NotSupportedException
+money	uz	bgn	1.005	EX:NotSupportedException
+money	uz	etb	0	EX:NotSupportedException
+money	uz	etb	0.01	EX:NotSupportedException
+money	uz	etb	0.02	EX:NotSupportedException
+money	uz	etb	1	EX:NotSupportedException
+money	uz	etb	1.01	EX:NotSupportedException
+money	uz	etb	1.02	EX:NotSupportedException
+money	uz	etb	2	EX:NotSupportedException
+money	uz	etb	2.02	EX:NotSupportedException
+money	uz	etb	3	EX:NotSupportedException
+money	uz	etb	5	EX:NotSupportedException
+money	uz	etb	11	EX:NotSupportedException
+money	uz	etb	21	EX:NotSupportedException
+money	uz	etb	22	EX:NotSupportedException
+money	uz	etb	42	EX:NotSupportedException
+money	uz	etb	100	EX:NotSupportedException
+money	uz	etb	101	EX:NotSupportedException
+money	uz	etb	121	EX:NotSupportedException
+money	uz	etb	999	EX:NotSupportedException
+money	uz	etb	1000	EX:NotSupportedException
+money	uz	etb	1001	EX:NotSupportedException
+money	uz	etb	2000	EX:NotSupportedException
+money	uz	etb	2001	EX:NotSupportedException
+money	uz	etb	5000	EX:NotSupportedException
+money	uz	etb	21000	EX:NotSupportedException
+money	uz	etb	22000	EX:NotSupportedException
+money	uz	etb	41000	EX:NotSupportedException
+money	uz	etb	42000	EX:NotSupportedException
+money	uz	etb	100000	EX:NotSupportedException
+money	uz	etb	1000000	EX:NotSupportedException
+money	uz	etb	2000000	EX:NotSupportedException
+money	uz	etb	1000000000	EX:NotSupportedException
+money	uz	etb	123.45	EX:NotSupportedException
+money	uz	etb	-1	EX:NotSupportedException
+money	uz	etb	-2	EX:NotSupportedException
+money	uz	etb	-41.5	EX:NotSupportedException
+money	uz	etb	-1000	EX:NotSupportedException
+money	uz	etb	1.999	EX:NotSupportedException
+money	uz	etb	123.456	EX:NotSupportedException
+money	uz	etb	1.005	EX:NotSupportedException
+money	uz	pln	0	EX:NotSupportedException
+money	uz	pln	0.01	EX:NotSupportedException
+money	uz	pln	0.02	EX:NotSupportedException
+money	uz	pln	1	EX:NotSupportedException
+money	uz	pln	1.01	EX:NotSupportedException
+money	uz	pln	1.02	EX:NotSupportedException
+money	uz	pln	2	EX:NotSupportedException
+money	uz	pln	2.02	EX:NotSupportedException
+money	uz	pln	3	EX:NotSupportedException
+money	uz	pln	5	EX:NotSupportedException
+money	uz	pln	11	EX:NotSupportedException
+money	uz	pln	21	EX:NotSupportedException
+money	uz	pln	22	EX:NotSupportedException
+money	uz	pln	42	EX:NotSupportedException
+money	uz	pln	100	EX:NotSupportedException
+money	uz	pln	101	EX:NotSupportedException
+money	uz	pln	121	EX:NotSupportedException
+money	uz	pln	999	EX:NotSupportedException
+money	uz	pln	1000	EX:NotSupportedException
+money	uz	pln	1001	EX:NotSupportedException
+money	uz	pln	2000	EX:NotSupportedException
+money	uz	pln	2001	EX:NotSupportedException
+money	uz	pln	5000	EX:NotSupportedException
+money	uz	pln	21000	EX:NotSupportedException
+money	uz	pln	22000	EX:NotSupportedException
+money	uz	pln	41000	EX:NotSupportedException
+money	uz	pln	42000	EX:NotSupportedException
+money	uz	pln	100000	EX:NotSupportedException
+money	uz	pln	1000000	EX:NotSupportedException
+money	uz	pln	2000000	EX:NotSupportedException
+money	uz	pln	1000000000	EX:NotSupportedException
+money	uz	pln	123.45	EX:NotSupportedException
+money	uz	pln	-1	EX:NotSupportedException
+money	uz	pln	-2	EX:NotSupportedException
+money	uz	pln	-41.5	EX:NotSupportedException
+money	uz	pln	-1000	EX:NotSupportedException
+money	uz	pln	1.999	EX:NotSupportedException
+money	uz	pln	123.456	EX:NotSupportedException
+money	uz	pln	1.005	EX:NotSupportedException
+money	uz	byn	0	EX:NotSupportedException
+money	uz	byn	0.01	EX:NotSupportedException
+money	uz	byn	0.02	EX:NotSupportedException
+money	uz	byn	1	EX:NotSupportedException
+money	uz	byn	1.01	EX:NotSupportedException
+money	uz	byn	1.02	EX:NotSupportedException
+money	uz	byn	2	EX:NotSupportedException
+money	uz	byn	2.02	EX:NotSupportedException
+money	uz	byn	3	EX:NotSupportedException
+money	uz	byn	5	EX:NotSupportedException
+money	uz	byn	11	EX:NotSupportedException
+money	uz	byn	21	EX:NotSupportedException
+money	uz	byn	22	EX:NotSupportedException
+money	uz	byn	42	EX:NotSupportedException
+money	uz	byn	100	EX:NotSupportedException
+money	uz	byn	101	EX:NotSupportedException
+money	uz	byn	121	EX:NotSupportedException
+money	uz	byn	999	EX:NotSupportedException
+money	uz	byn	1000	EX:NotSupportedException
+money	uz	byn	1001	EX:NotSupportedException
+money	uz	byn	2000	EX:NotSupportedException
+money	uz	byn	2001	EX:NotSupportedException
+money	uz	byn	5000	EX:NotSupportedException
+money	uz	byn	21000	EX:NotSupportedException
+money	uz	byn	22000	EX:NotSupportedException
+money	uz	byn	41000	EX:NotSupportedException
+money	uz	byn	42000	EX:NotSupportedException
+money	uz	byn	100000	EX:NotSupportedException
+money	uz	byn	1000000	EX:NotSupportedException
+money	uz	byn	2000000	EX:NotSupportedException
+money	uz	byn	1000000000	EX:NotSupportedException
+money	uz	byn	123.45	EX:NotSupportedException
+money	uz	byn	-1	EX:NotSupportedException
+money	uz	byn	-2	EX:NotSupportedException
+money	uz	byn	-41.5	EX:NotSupportedException
+money	uz	byn	-1000	EX:NotSupportedException
+money	uz	byn	1.999	EX:NotSupportedException
+money	uz	byn	123.456	EX:NotSupportedException
+money	uz	byn	1.005	EX:NotSupportedException
+money	uz	ars	0	EX:NotSupportedException
+money	uz	ars	0.01	EX:NotSupportedException
+money	uz	ars	0.02	EX:NotSupportedException
+money	uz	ars	1	EX:NotSupportedException
+money	uz	ars	1.01	EX:NotSupportedException
+money	uz	ars	1.02	EX:NotSupportedException
+money	uz	ars	2	EX:NotSupportedException
+money	uz	ars	2.02	EX:NotSupportedException
+money	uz	ars	3	EX:NotSupportedException
+money	uz	ars	5	EX:NotSupportedException
+money	uz	ars	11	EX:NotSupportedException
+money	uz	ars	21	EX:NotSupportedException
+money	uz	ars	22	EX:NotSupportedException
+money	uz	ars	42	EX:NotSupportedException
+money	uz	ars	100	EX:NotSupportedException
+money	uz	ars	101	EX:NotSupportedException
+money	uz	ars	121	EX:NotSupportedException
+money	uz	ars	999	EX:NotSupportedException
+money	uz	ars	1000	EX:NotSupportedException
+money	uz	ars	1001	EX:NotSupportedException
+money	uz	ars	2000	EX:NotSupportedException
+money	uz	ars	2001	EX:NotSupportedException
+money	uz	ars	5000	EX:NotSupportedException
+money	uz	ars	21000	EX:NotSupportedException
+money	uz	ars	22000	EX:NotSupportedException
+money	uz	ars	41000	EX:NotSupportedException
+money	uz	ars	42000	EX:NotSupportedException
+money	uz	ars	100000	EX:NotSupportedException
+money	uz	ars	1000000	EX:NotSupportedException
+money	uz	ars	2000000	EX:NotSupportedException
+money	uz	ars	1000000000	EX:NotSupportedException
+money	uz	ars	123.45	EX:NotSupportedException
+money	uz	ars	-1	EX:NotSupportedException
+money	uz	ars	-2	EX:NotSupportedException
+money	uz	ars	-41.5	EX:NotSupportedException
+money	uz	ars	-1000	EX:NotSupportedException
+money	uz	ars	1.999	EX:NotSupportedException
+money	uz	ars	123.456	EX:NotSupportedException
+money	uz	ars	1.005	EX:NotSupportedException
+money	uz	brl	0	EX:NotSupportedException
+money	uz	brl	0.01	EX:NotSupportedException
+money	uz	brl	0.02	EX:NotSupportedException
+money	uz	brl	1	EX:NotSupportedException
+money	uz	brl	1.01	EX:NotSupportedException
+money	uz	brl	1.02	EX:NotSupportedException
+money	uz	brl	2	EX:NotSupportedException
+money	uz	brl	2.02	EX:NotSupportedException
+money	uz	brl	3	EX:NotSupportedException
+money	uz	brl	5	EX:NotSupportedException
+money	uz	brl	11	EX:NotSupportedException
+money	uz	brl	21	EX:NotSupportedException
+money	uz	brl	22	EX:NotSupportedException
+money	uz	brl	42	EX:NotSupportedException
+money	uz	brl	100	EX:NotSupportedException
+money	uz	brl	101	EX:NotSupportedException
+money	uz	brl	121	EX:NotSupportedException
+money	uz	brl	999	EX:NotSupportedException
+money	uz	brl	1000	EX:NotSupportedException
+money	uz	brl	1001	EX:NotSupportedException
+money	uz	brl	2000	EX:NotSupportedException
+money	uz	brl	2001	EX:NotSupportedException
+money	uz	brl	5000	EX:NotSupportedException
+money	uz	brl	21000	EX:NotSupportedException
+money	uz	brl	22000	EX:NotSupportedException
+money	uz	brl	41000	EX:NotSupportedException
+money	uz	brl	42000	EX:NotSupportedException
+money	uz	brl	100000	EX:NotSupportedException
+money	uz	brl	1000000	EX:NotSupportedException
+money	uz	brl	2000000	EX:NotSupportedException
+money	uz	brl	1000000000	EX:NotSupportedException
+money	uz	brl	123.45	EX:NotSupportedException
+money	uz	brl	-1	EX:NotSupportedException
+money	uz	brl	-2	EX:NotSupportedException
+money	uz	brl	-41.5	EX:NotSupportedException
+money	uz	brl	-1000	EX:NotSupportedException
+money	uz	brl	1.999	EX:NotSupportedException
+money	uz	brl	123.456	EX:NotSupportedException
+money	uz	brl	1.005	EX:NotSupportedException
 money	uz	uzs	0	nol so'm nol tiyin
 money	uz	uzs	0.01	nol so'm bir tiyin
 money	uz	uzs	0.02	nol so'm ikki tiyin
@@ -6953,45 +6953,45 @@ money	uz	uzs	-1000	minus ming so'm nol tiyin
 money	uz	uzs	1.999	ikki so'm nol tiyin
 money	uz	uzs	123.456	yuz yigirma uch so'm qirq olti tiyin
 money	uz	uzs	1.005	bir so'm bir tiyin
-money	uz	gbp	0	nol funt sterling nol pens
-money	uz	gbp	0.01	nol funt sterling bir pens
-money	uz	gbp	0.02	nol funt sterling ikki pens
-money	uz	gbp	1	bir funt sterling nol pens
-money	uz	gbp	1.01	bir funt sterling bir pens
-money	uz	gbp	1.02	bir funt sterling ikki pens
-money	uz	gbp	2	ikki funt sterling nol pens
-money	uz	gbp	2.02	ikki funt sterling ikki pens
-money	uz	gbp	3	uch funt sterling nol pens
-money	uz	gbp	5	besh funt sterling nol pens
-money	uz	gbp	11	o'n bir funt sterling nol pens
-money	uz	gbp	21	yigirma bir funt sterling nol pens
-money	uz	gbp	22	yigirma ikki funt sterling nol pens
-money	uz	gbp	42	qirq ikki funt sterling nol pens
-money	uz	gbp	100	yuz funt sterling nol pens
-money	uz	gbp	101	yuz bir funt sterling nol pens
-money	uz	gbp	121	yuz yigirma bir funt sterling nol pens
-money	uz	gbp	999	to'qqiz yuz to'qson to'qqiz funt sterling nol pens
-money	uz	gbp	1000	ming funt sterling nol pens
-money	uz	gbp	1001	ming bir funt sterling nol pens
-money	uz	gbp	2000	ikki ming funt sterling nol pens
-money	uz	gbp	2001	ikki ming bir funt sterling nol pens
-money	uz	gbp	5000	besh ming funt sterling nol pens
-money	uz	gbp	21000	yigirma bir ming funt sterling nol pens
-money	uz	gbp	22000	yigirma ikki ming funt sterling nol pens
-money	uz	gbp	41000	qirq bir ming funt sterling nol pens
-money	uz	gbp	42000	qirq ikki ming funt sterling nol pens
-money	uz	gbp	100000	yuz ming funt sterling nol pens
-money	uz	gbp	1000000	bir million funt sterling nol pens
-money	uz	gbp	2000000	ikki million funt sterling nol pens
-money	uz	gbp	1000000000	bir milliard funt sterling nol pens
-money	uz	gbp	123.45	yuz yigirma uch funt sterling qirq besh pens
-money	uz	gbp	-1	minus bir funt sterling nol pens
-money	uz	gbp	-2	minus ikki funt sterling nol pens
-money	uz	gbp	-41.5	minus qirq bir funt sterling ellik pens
-money	uz	gbp	-1000	minus ming funt sterling nol pens
-money	uz	gbp	1.999	ikki funt sterling nol pens
-money	uz	gbp	123.456	yuz yigirma uch funt sterling qirq olti pens
-money	uz	gbp	1.005	bir funt sterling bir pens
+money	uz	gbp	0	EX:NotSupportedException
+money	uz	gbp	0.01	EX:NotSupportedException
+money	uz	gbp	0.02	EX:NotSupportedException
+money	uz	gbp	1	EX:NotSupportedException
+money	uz	gbp	1.01	EX:NotSupportedException
+money	uz	gbp	1.02	EX:NotSupportedException
+money	uz	gbp	2	EX:NotSupportedException
+money	uz	gbp	2.02	EX:NotSupportedException
+money	uz	gbp	3	EX:NotSupportedException
+money	uz	gbp	5	EX:NotSupportedException
+money	uz	gbp	11	EX:NotSupportedException
+money	uz	gbp	21	EX:NotSupportedException
+money	uz	gbp	22	EX:NotSupportedException
+money	uz	gbp	42	EX:NotSupportedException
+money	uz	gbp	100	EX:NotSupportedException
+money	uz	gbp	101	EX:NotSupportedException
+money	uz	gbp	121	EX:NotSupportedException
+money	uz	gbp	999	EX:NotSupportedException
+money	uz	gbp	1000	EX:NotSupportedException
+money	uz	gbp	1001	EX:NotSupportedException
+money	uz	gbp	2000	EX:NotSupportedException
+money	uz	gbp	2001	EX:NotSupportedException
+money	uz	gbp	5000	EX:NotSupportedException
+money	uz	gbp	21000	EX:NotSupportedException
+money	uz	gbp	22000	EX:NotSupportedException
+money	uz	gbp	41000	EX:NotSupportedException
+money	uz	gbp	42000	EX:NotSupportedException
+money	uz	gbp	100000	EX:NotSupportedException
+money	uz	gbp	1000000	EX:NotSupportedException
+money	uz	gbp	2000000	EX:NotSupportedException
+money	uz	gbp	1000000000	EX:NotSupportedException
+money	uz	gbp	123.45	EX:NotSupportedException
+money	uz	gbp	-1	EX:NotSupportedException
+money	uz	gbp	-2	EX:NotSupportedException
+money	uz	gbp	-41.5	EX:NotSupportedException
+money	uz	gbp	-1000	EX:NotSupportedException
+money	uz	gbp	1.999	EX:NotSupportedException
+money	uz	gbp	123.456	EX:NotSupportedException
+money	uz	gbp	1.005	EX:NotSupportedException
 plain	lv	0	nulle
 plain	lv	1	viens
 plain	lv	2	divi

--- a/src/Nut/Extensions.cs
+++ b/src/Nut/Extensions.cs
@@ -54,7 +54,6 @@ namespace Nut
                 { Culture.EthiopianAM, AmharicConverter.Instance },
             };
 
-        /// <summary>Returns null for an unknown language, which callers render as "".</summary>
         /// <summary>
         /// An unsupported language is an error rather than an empty result. This library
         /// writes amounts onto invoices and cheques, where a blank in the amount field is

--- a/src/Nut/TextConverters/BaseConverter.cs
+++ b/src/Nut/TextConverters/BaseConverter.cs
@@ -240,8 +240,10 @@ namespace Nut.TextConverters
         {
           // "and 50/100", the form used on cheques. The sub-unit is not named, and zero is
           // written rather than dropped, so nothing can be appended to the amount later.
+          // Blank counts as absent, not as "join them with nothing": an override returning
+          // "" would otherwise slip past and produce "dollars50/100".
           var separator = GetFractionSeparator(currencyModel);
-          if (separator == null)
+          if (string.IsNullOrWhiteSpace(separator))
           {
             throw new NotSupportedException(string.Format(
               "SubUnitFormat.Fraction is not defined for {0}. Writing the sub-unit over a " +
@@ -303,20 +305,21 @@ namespace Nut.TextConverters
     }
 
     /// <summary>
-    /// What joins the amount to a fraction-form sub-unit. Languages that already join the
-    /// two parts with a word reuse that word; the rest return null, and asking for the
-    /// fraction form in one of them fails rather than guessing.
+    /// What joins the amount to a fraction-form sub-unit, or null if the language has no
+    /// wording for the form. Null is the default: a converter has to state the word before
+    /// <see cref="SubUnitFormat.Fraction"/> works, and until it does, asking for it fails.
     /// <para>
-    /// This used to fall back to the English "and" whenever a converter left the unit
-    /// separator as a plain space, which is nine of the fourteen — so a Russian cheque read
-    /// "сто пять рублей and 50/100". Writing over-a-hundred is an anglophone cheque
-    /// convention, and the languages that do not have it have no separator to borrow.
+    /// Writing the sub-unit over a hundred is an anglophone cheque convention rather than a
+    /// rule of any language, so only English states one. This first fell back to the English
+    /// "and" for every converter that left the unit separator as a plain space, which put it
+    /// into nine of the fourteen — "сто пять рублей and 50/100". Deriving it from the unit
+    /// separator instead reached five more, but that only narrowed the guess: having a word
+    /// for "and" is not evidence that a country's cheques carry 50/100 at all.
     /// </para>
     /// </summary>
     protected virtual string GetFractionSeparator(CurrencyModel currency)
     {
-      var separator = GetUnitSeparator(currency);
-      return separator.Trim().Length > 0 ? separator : null;
+      return null;
     }
     #endregion
   }

--- a/src/Nut/TextConverters/BaseConverter.cs
+++ b/src/Nut/TextConverters/BaseConverter.cs
@@ -190,6 +190,12 @@ namespace Nut.TextConverters
         ? Math.Truncate(num * 100) / 100
         : Math.Round(num, 2, MidpointRounding.AwayFromZero);
 
+      // Rounding can carry an in-range amount over the limit — 999999999999.995 becomes a
+      // trillion — and only one of the two output paths converts to long afterwards, so
+      // the check below is the only thing standing between that and a rendered amount the
+      // library says it cannot produce.
+      NumberLimitControl(num);
+
       // An amount too small to register, like -0.001, rounds to zero; "minus zero" is not
       // an amount anyone writes.
       if (num == 0) isNegative = false;

--- a/src/Nut/TextConverters/FrenchConverter.cs
+++ b/src/Nut/TextConverters/FrenchConverter.cs
@@ -212,7 +212,9 @@ namespace Nut.TextConverters
           return new CurrencyModel
           {
             Currency = currency,
-            Names = new[] { "réal brésilien", "réals brésiliens" },
+            // Académie française, 9th edition: réal, plural réaux. The OQLF writes
+            // "des réaux brésiliens" too; "réals" is in no dictionary.
+            Names = new[] { "réal brésilien", "réaux brésiliens" },
             Gender = GenderGroup.Masculine,
             SubUnitCurrency = new BaseCurrencyModel { Gender = GenderGroup.Masculine, Names = new[] { "centavo", "centavos" } }
           };

--- a/src/Nut/TextConverters/LatvianConverter.cs
+++ b/src/Nut/TextConverters/LatvianConverter.cs
@@ -84,12 +84,20 @@ namespace Nut.TextConverters
     }
 
     /// <summary>
-    /// Singular after a count ending in one (but not eleven), genitive plural after zero,
-    /// plural otherwise.
+    /// Genitive plural after zero and after a scale word, singular after a count ending in
+    /// one (but not eleven), plural otherwise.
+    /// <para>
+    /// The declinable scale words — simts, tūkstotis, miljons, miljards — govern the
+    /// genitive plural of what they count: "viens tūkstotis dolāru", not "dolāri". One of
+    /// them is the last word spoken whenever the amount ends in two zeros, which is what
+    /// the modulo test detects. Ten is not among them (desmit does not decline), so
+    /// "desmit dolāri" and "simts desmit dolāri" stay in the nominative.
+    /// </para>
     /// </summary>
     private static string Inflect(long num, string[] names)
     {
-      if (num == 0) return names.Length > 2 ? names[2] : names[1];
+      var genitivePlural = names.Length > 2 ? names[2] : names[1];
+      if (num == 0 || num % 100 == 0) return genitivePlural;
       if (num % 10 == 1 && num % 100 != 11) return names[0];
       return names[1];
     }

--- a/src/Nut/TextConverters/PortugueseConverter.cs
+++ b/src/Nut/TextConverters/PortugueseConverter.cs
@@ -9,7 +9,7 @@ namespace Nut.TextConverters
         private static readonly Lazy<PortugueseConverter> Lazy = new Lazy<PortugueseConverter>(() => new PortugueseConverter());
         public static PortugueseConverter Instance => Lazy.Value;
 
-        public override string CultureName => Culture.Spanish;
+        public override string CultureName => Culture.PortugueseBR;
 
         protected override string NegativeSign => "menos";
 
@@ -191,7 +191,10 @@ namespace Nut.TextConverters
                   return new CurrencyModel
                   {
                     Currency = currency,
-                    Names = new[] { "som uzbeque", "soms uzbeques" },
+                    // Priberam keeps these apart: "som" is the Kyrgyz currency (KGS) and
+                    // "sum" the Uzbek one (UZS), so this used to name the wrong country's
+                    // money. The plural is "sumes", not "soms".
+                    Names = new[] { "sum usbeque", "sumes usbeques" },
                     Gender = GenderGroup.Masculine,
                     SubUnitCurrency = new BaseCurrencyModel { Gender = GenderGroup.Masculine, Names = new[] { "tiyin", "tiyin" } }
                   };

--- a/src/Nut/TextConverters/UzbekConverter.cs
+++ b/src/Nut/TextConverters/UzbekConverter.cs
@@ -100,6 +100,12 @@ namespace Nut.TextConverters
 
     protected override CurrencyModel GetCurrencyModel(string currency)
     {
+      // The three the Uzbek contributor supplied in #23, and only those. The other ten
+      // were filled in for parity, and their sub-unit names are in no Uzbek source — five
+      // came out as "tiyin", which is the som's own sub-unit and not the Turkish lira's or
+      // the hryvnia's. #23 had the rouble right, with "kopeyka", and the parity pass wrote
+      // over it. An amount naming the wrong sub-unit on an invoice is worse than one that
+      // fails, so the invented ten are gone until someone who reads Uzbek supplies them.
       switch (currency)
       {
         case Currency.UZS:
@@ -109,62 +115,6 @@ namespace Nut.TextConverters
             Names = new[] { "so'm", "so'm" },
             SubUnitCurrency = new BaseCurrencyModel { Names = new[] { "tiyin", "tiyin" } }
           };
-        case Currency.GBP:
-          return new CurrencyModel
-          {
-            Currency = currency,
-            Names = new[] { "funt sterling", "funt sterling" },
-            SubUnitCurrency = new BaseCurrencyModel { Names = new[] { "pens", "pens" } }
-          };
-        case Currency.ARS:
-          return new CurrencyModel
-          {
-            Currency = currency,
-            Names = new[] { "Argentina pesosi", "Argentina pesosi" },
-            SubUnitCurrency = new BaseCurrencyModel { Names = new[] { "sentavo", "sentavo" } }
-          };
-        case Currency.BGN:
-          return new CurrencyModel
-          {
-            Currency = currency,
-            Names = new[] { "Bolgariya levi", "Bolgariya levi" },
-            SubUnitCurrency = new BaseCurrencyModel { Names = new[] { "stotinka", "stotinka" } }
-          };
-        case Currency.BRL:
-          return new CurrencyModel
-          {
-            Currency = currency,
-            Names = new[] { "Braziliya reali", "Braziliya reali" },
-            SubUnitCurrency = new BaseCurrencyModel { Names = new[] { "sentavo", "sentavo" } }
-          };
-        case Currency.BYN:
-          return new CurrencyModel
-          {
-            Currency = currency,
-            Names = new[] { "Belarus rubli", "Belarus rubli" },
-            SubUnitCurrency = new BaseCurrencyModel { Names = new[] { "tiyin", "tiyin" } }
-          };
-        case Currency.ETB:
-          return new CurrencyModel
-          {
-            Currency = currency,
-            Names = new[] { "Efiopiya biri", "Efiopiya biri" },
-            SubUnitCurrency = new BaseCurrencyModel { Names = new[] { "tiyin", "tiyin" } }
-          };
-        case Currency.PLN:
-          return new CurrencyModel
-          {
-            Currency = currency,
-            Names = new[] { "Polsha zlotiysi", "Polsha zlotiysi" },
-            SubUnitCurrency = new BaseCurrencyModel { Names = new[] { "grosh", "grosh" } }
-          };
-        case Currency.UAH:
-          return new CurrencyModel
-          {
-            Currency = currency,
-            Names = new[] { "Ukraina grivnasi", "Ukraina grivnasi" },
-            SubUnitCurrency = new BaseCurrencyModel { Names = new[] { "tiyin", "tiyin" } }
-          };
         case Currency.USD:
           return new CurrencyModel
           {
@@ -172,28 +122,15 @@ namespace Nut.TextConverters
             Names = new[] { "dollar", "dollar" },
             SubUnitCurrency = new BaseCurrencyModel { Names = new[] { "sent", "sent" } }
           };
-        case Currency.EUR:
-          return new CurrencyModel
-          {
-            Currency = currency,
-            Names = new[] { "yevro", "yevro" },
-            SubUnitCurrency = new BaseCurrencyModel { Names = new[] { "sent", "sent" } }
-          };
         case Currency.RUB:
           return new CurrencyModel
           {
             Currency = currency,
             Names = new[] { "rubl", "rubl" },
-            SubUnitCurrency = new BaseCurrencyModel { Names = new[] { "tiyin", "tiyin" } }
-          };
-        case Currency.TRY:
-          return new CurrencyModel
-          {
-            Currency = currency,
-            Names = new[] { "turk lirasi", "turk lirasi" },
-            SubUnitCurrency = new BaseCurrencyModel { Names = new[] { "tiyin", "tiyin" } }
+            SubUnitCurrency = new BaseCurrencyModel { Names = new[] { "kopeyka", "kopeyka" } }
           };
       }
+
       return null;
     }
   }


### PR DESCRIPTION
Second round, five sources this time, including four language agents with dictionaries. Most of what I had written from pattern turned out right. Four things did not.

## Latvian was wrong on round amounts

The declinable scale words — `simts`, `tūkstotis`, `miljons`, `miljards` — govern the genitive plural of what they count. The converter wrote the nominative, so `1000 USD` read `viens tūkstotis ASV dolāri` where it should be `dolāru`. It applies wherever the amount ends on one of those words, which is every round amount, so this was wrong on exactly the shape a document is most likely to carry. `desmit` does not decline and governs nothing, so `simts desmit dolāri` stays as it is.

Source: uzdevumi.lv, *"Aiz lokāmajām formām desmits, simts, tūkstotis, miljons, miljards pieņemts lietot lietvārdu daudzskaitļa ģenitīvā"*, and valodaskonsultacijas.lv giving `pieci tūkstoši cilvēku`.

**The test I added in #65 pinned the nominative**, so it was defending the bug. Replaced with two: one for what the scale words govern, one for the boundary where ten does not.

## Portuguese named the wrong country's money

Priberam keeps `som` (Kyrgyz som, KGS) and `sum` (Uzbek sum, UZS) as separate entries, and the library used the first for the second. `soms` is not a possible Portuguese plural either. Now `sum usbeque` / `sumes usbeques`. I checked both entries directly rather than taking the report's word for it.

## French `réals` is in no dictionary

Académie française, ninth edition: `réal`, plural `réaux`. The OQLF writes `des réaux brésiliens`. Checked the Académie entry directly.

## Rounding could cross the range limit

`999999999999.995` threw on the default path and rendered as `1000000000000 dollars` with the whole part left as digits. One input, two answers, depending on the output format. The check runs again after rounding.

## `PortugueseConverter.CultureName` returned `es-ES`

A copy-paste from the commit that first added the converter. Casing is unaffected, both being Latin script, but the culture names the language in the unsupported-currency message, and that message gets read now that it is thrown rather than swallowed.

## Two things the review argued me out of

**The fraction form is English only now.** I had it in seven languages, on the reasoning that they have a word joining the two parts of an amount. The review pointed out that a word for "and" is not evidence that a country writes 50/100 on a cheque, which is fair — it was a narrower guess, not a sourced one.

**Uzbek covers `UZS`, `USD` and `RUB`.** The ten I added for parity have sub-unit names that are in no Uzbek source, and five came out as `tiyin`, which is the som's own sub-unit and not the Turkish lira's. Worse, #23 had the rouble right, with `kopeyka`, and my parity pass wrote over a native speaker's own word. Restored those three, dropped the invented ten.

## One thing the report got wrong

It attributes Amharic's `ሳንቲም` covering eight currencies, and `ETB → копейка` in Russian, Belarusian and Bulgarian, to this release. Both are byte-identical to 3.4.1. Amharic's currency list has not changed at all this cycle. Real problems, but pre-existing and outside what this release touched — and Amharic content is not something I can verify either way.

## Not done

- `leva bulgares` in French. The report cites Larousse for `lev, pl. leva`; I fetched the Larousse entry and it gives no plural. Unverified, so unchanged.
- `kurušs`, `sentavo` in Latvian, and the Uzbek apostrophe. The first two are sourced to Tēzaurs and worth doing; the apostrophe you already decided against.
- The unsourceable list in §5 still needs native speakers.

650 tests, no warnings. 143 Latvian, 429 Uzbek, 39 Portuguese and 31 French rows move in the snapshot.