### PR TITLE
release: 4.0.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,8 @@ version rather than a complete list.
 
 ## [Unreleased]
 
+## [4.0.0] - 2026-07-29
+
 Every change below alters produced text, so this is **4.0.0** rather than a minor release.
 
 Measured against the published 3.4.1 over 5520 conversions — the twelve languages it
@@ -418,7 +420,8 @@ Initial release, with English, Spanish and Turkish.
 <!-- Bulgarian (2017) shipped between 2.4.2 and 3.0.0; the exact version is not
      recoverable from the available history. -->
 
-[Unreleased]: https://github.com/emrahyumuk/NUT-number-to-text/compare/v3.5.0...HEAD
+[Unreleased]: https://github.com/emrahyumuk/NUT-number-to-text/compare/v4.0.0...HEAD
+[4.0.0]: https://www.nuget.org/packages/Nut/4.0.0
 [3.5.0]: https://github.com/emrahyumuk/NUT-number-to-text/releases/tag/v3.5.0
 [3.4.1]: https://www.nuget.org/packages/Nut/3.4.1
 [3.3.0]: https://www.nuget.org/packages/Nut/3.3.0

--- a/src/Nut/Nut.csproj
+++ b/src/Nut/Nut.csproj
@@ -18,7 +18,7 @@ Number Limit: 1 trillion</Description>
     <RepositoryUrl>https://github.com/emrahyumuk/NUT-number-to-text</RepositoryUrl>
     <RepositoryType>git</RepositoryType>
     <PackageReadmeFile>README.md</PackageReadmeFile>
-    <PackageTags>number, text, word, money, english, french, turkish, spanish, russian, german currency, try, usd, euro, rub, number, to money, currency, int, decimal, ukranian, UAH, bulgarian, portuguese, BRL, BGN, amharic, ETB, polish, PLN, Belarussian, BLN, ARS, argentine pesos</PackageTags>
+    <PackageTags>number-to-text;number-to-words;money-to-words;amount-in-words;spell-number;currency;invoice;cheque;localization;english;french;german;spanish;portuguese;turkish;russian;ukrainian;belarusian;bulgarian;polish;latvian;uzbek;amharic;EUR;USD;GBP;RUB;TRY;UAH;BGN;ETB;PLN;BYN;ARS;BRL;UZS</PackageTags>
   </PropertyGroup>
   <ItemGroup>
     <None Include="..\..\README.md" Pack="true" PackagePath="\"/>


### PR DESCRIPTION
Closes the changelog. `[Unreleased]` becomes `[4.0.0] - 2026-07-29`, with a fresh empty `[Unreleased]` above it and the compare link repointed.

Also rewrites `PackageTags`, which is the NuGet listing's search surface and had gone stale: `BLN` for the Belarusian rouble, `ukranian` misspelled, no Uzbek, Latvian, `UZS` or `GBP`, and a stray `german currency` from a missing comma. Semicolon-separated now, which is what NuGet expects, and it leads with what people actually search for.

Verified the pack before tagging:

```
dotnet pack -p:Version=4.0.0
  Nut.4.0.0.nupkg    <version>4.0.0</version>    lib/netstandard2.0/Nut.dll
```

The version comes from the tag, so nothing in the csproj pins it. Merging this and pushing `v4.0.0` triggers the release workflow: test, pack, NuGet trusted publish, GitHub release.

650 tests, no warnings.